### PR TITLE
Add BSL 1.1 license, copyright headers, and dependency audit

### DIFF
--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -16,13 +16,8 @@ These conventions ensure that code from parallel agents merges cleanly. All agen
 Required on all C# source files:
 
 ```csharp
-/*
- * Copyright CVOYA LLC.
- *
- * This source code is proprietary and confidential.
- * Unauthorized copying, modification, distribution, or use of this file,
- * via any medium, is strictly prohibited without the prior written consent of CVOYA LLC.
- */
+// Copyright CVOYA LLC. Licensed under the Business Source License 1.1.
+// See LICENSE.md in the project root for full license terms.
 ```
 
 ### Namespace and Using Order
@@ -30,9 +25,8 @@ Required on all C# source files:
 File-scoped namespaces. Namespace declaration immediately after the copyright header, `using` statements after:
 
 ```csharp
-/*
- * Copyright CVOYA LLC. ...
- */
+// Copyright CVOYA LLC. Licensed under the Business Source License 1.1.
+// See LICENSE.md in the project root for full license terms.
 
 namespace Cvoya.Spring.Core.Messaging;
 

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,51 @@
+# Business Source License 1.1
+
+## Parameters
+
+| Parameter | Value |
+|-----------|-------|
+| **Licensor** | CVOYA LLC |
+| **Licensed Work** | Spring Voyage. The Licensed Work is (c) 2025 CVOYA LLC. |
+| **Additional Use Grant** | You may make production use of the Licensed Work, provided such use does not include offering the Licensed Work to third parties as a managed AI agent orchestration service (a service that allows third parties to create, manage, and run AI agents using the Licensed Work as part of the service's core functionality). |
+| **Change Date** | 2030-04-10 |
+| **Change License** | Apache License, Version 2.0 |
+
+For information about alternative licensing arrangements for the Licensed Work, please contact the Licensor.
+
+---
+
+## Notice
+
+License text copyright (c) 2017 MariaDB Corporation Ab, All Rights Reserved. "Business Source License" is a trademark of MariaDB Corporation Ab.
+
+## Terms
+
+The Licensor hereby grants you the right to copy, modify, create derivative works, redistribute, and make non-production use of the Licensed Work. The Licensor may make an Additional Use Grant, above, permitting limited production use.
+
+Effective on the Change Date, or the fourth anniversary of the first publicly available distribution of a specific version of the Licensed Work under this License, whichever comes first, the Licensor hereby grants you rights under the terms of the Change License, and the rights granted in the paragraph above terminate.
+
+If your use of the Licensed Work does not comply with the requirements currently in effect as described in this License, you must purchase a commercial license from the Licensor, its affiliated entities, or authorized resellers, or you must refrain from using the Licensed Work.
+
+All copies of the original and modified Licensed Work, and derivative works of the Licensed Work, are subject to this License. This License applies separately for each version of the Licensed Work and the Change Date may vary for each version of the Licensed Work released by Licensor.
+
+You must conspicuously display this License on each original or modified copy of the Licensed Work. If you receive the Licensed Work in original or modified form from a third party, the terms and conditions set forth in this License apply to your use of that work.
+
+Any use of the Licensed Work in violation of this License will automatically terminate your rights under this License for the current and all other versions of the Licensed Work.
+
+This License does not grant you any right in any trademark or logo of Licensor or its affiliates (provided that you may use a trademark or logo of Licensor as expressly required by this License).
+
+TO THE EXTENT PERMITTED BY APPLICABLE LAW, THE LICENSED WORK IS PROVIDED ON AN "AS IS" BASIS. LICENSOR HEREBY DISCLAIMS ALL WARRANTIES AND CONDITIONS, EXPRESS OR IMPLIED, INCLUDING (WITHOUT LIMITATION) WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, NON-INFRINGEMENT, AND TITLE.
+
+MariaDB hereby grants you permission to use this License's text to license your works, and to refer to it using the trademark "Business Source License", as long as you comply with the Covenants of Licensor below.
+
+## Covenants of Licensor
+
+In consideration of the right to use this License's text and the "Business Source License" name and trademark, Licensor covenants to MariaDB, and to all other recipients of the licensed work to be provided by Licensor:
+
+1. To specify as the Change License the GPL Version 2.0 or any later version, or a license that is compatible with GPL Version 2.0 or a later version, where "compatible" means that software provided under the Change License can be included in a program with software provided under GPL Version 2.0 or a later version. Licensor may specify additional Change Licenses without limitation.
+
+2. To either: (a) specify an additional grant of rights to use that does not impose any additional restriction on the right granted in this License, as the Additional Use Grant; or (b) insert the text "None".
+
+3. To specify a Change Date.
+
+4. Not to modify this License in any other way.

--- a/NOTICE.md
+++ b/NOTICE.md
@@ -1,0 +1,21 @@
+# Spring Voyage
+
+Copyright 2025 CVOYA LLC
+
+This product is licensed under the Business Source License 1.1 (BSL 1.1).
+See the [LICENSE](LICENSE.md) file for the full license text.
+
+On the Change Date (2030-04-10), the license for each version converts to
+the Apache License, Version 2.0.
+
+## Third-Party Software
+
+This product includes or depends on the following third-party software:
+
+| Dependency | License | Source |
+|------------|---------|--------|
+| Dapr SDK for .NET | Apache License 2.0 | [dapr/dotnet-sdk](https://github.com/dapr/dotnet-sdk) |
+| Microsoft .NET and Extensions (ASP.NET Core, Entity Framework Core, System.CommandLine, System.IdentityModel.Tokens.Jwt, Microsoft.Extensions.*) | MIT License | [dotnet/runtime](https://github.com/dotnet/runtime) |
+| Npgsql / Npgsql.EntityFrameworkCore.PostgreSQL | PostgreSQL License | [npgsql/npgsql](https://github.com/npgsql/npgsql) |
+| Octokit.net | MIT License | [octokit/octokit.net](https://github.com/octokit/octokit.net) |
+| Swashbuckle.AspNetCore | MIT License | [domaindrivendev/Swashbuckle.AspNetCore](https://github.com/domaindrivendev/Swashbuckle.AspNetCore) |

--- a/README.md
+++ b/README.md
@@ -183,3 +183,15 @@ The platform uses the **Dapr sidecar pattern**. Each host process runs alongside
 ```
 
 For the full architecture, see `docs/SpringVoyage-v2-plan.md`.
+
+## License
+
+Spring Voyage is licensed under the [Business Source License 1.1](LICENSE.md).
+
+**What this means:**
+
+- **Free to use** for personal projects, development, testing, and internal non-production use
+- **Free for production** except for offering it as a competing managed AI agent orchestration service
+- **Converts to Apache 2.0** on 2030-04-10 (four years from initial release)
+
+See the [LICENSE](LICENSE.md) file for the full terms and the [NOTICE](NOTICE.md) file for third-party attributions.

--- a/packages/software-engineering/workflows/software-dev-cycle/SoftwareDevCycle/Activities/AssignByExpertiseActivity.cs
+++ b/packages/software-engineering/workflows/software-dev-cycle/SoftwareDevCycle/Activities/AssignByExpertiseActivity.cs
@@ -1,10 +1,5 @@
-/*
- * Copyright CVOYA LLC.
- *
- * This source code is proprietary and confidential.
- * Unauthorized copying, modification, distribution, or use of this file,
- * via any medium, is strictly prohibited without the prior written consent of CVOYA LLC.
- */
+// Copyright CVOYA LLC. Licensed under the Business Source License 1.1.
+// See LICENSE.md in the project root for full license terms.
 
 namespace Cvoya.Spring.Packages.SoftwareEngineering.Workflows.Activities;
 

--- a/packages/software-engineering/workflows/software-dev-cycle/SoftwareDevCycle/Activities/CreatePlanActivity.cs
+++ b/packages/software-engineering/workflows/software-dev-cycle/SoftwareDevCycle/Activities/CreatePlanActivity.cs
@@ -1,10 +1,5 @@
-/*
- * Copyright CVOYA LLC.
- *
- * This source code is proprietary and confidential.
- * Unauthorized copying, modification, distribution, or use of this file,
- * via any medium, is strictly prohibited without the prior written consent of CVOYA LLC.
- */
+// Copyright CVOYA LLC. Licensed under the Business Source License 1.1.
+// See LICENSE.md in the project root for full license terms.
 
 namespace Cvoya.Spring.Packages.SoftwareEngineering.Workflows.Activities;
 

--- a/packages/software-engineering/workflows/software-dev-cycle/SoftwareDevCycle/Activities/ImplementActivity.cs
+++ b/packages/software-engineering/workflows/software-dev-cycle/SoftwareDevCycle/Activities/ImplementActivity.cs
@@ -1,10 +1,5 @@
-/*
- * Copyright CVOYA LLC.
- *
- * This source code is proprietary and confidential.
- * Unauthorized copying, modification, distribution, or use of this file,
- * via any medium, is strictly prohibited without the prior written consent of CVOYA LLC.
- */
+// Copyright CVOYA LLC. Licensed under the Business Source License 1.1.
+// See LICENSE.md in the project root for full license terms.
 
 namespace Cvoya.Spring.Packages.SoftwareEngineering.Workflows.Activities;
 

--- a/packages/software-engineering/workflows/software-dev-cycle/SoftwareDevCycle/Activities/MergeActivity.cs
+++ b/packages/software-engineering/workflows/software-dev-cycle/SoftwareDevCycle/Activities/MergeActivity.cs
@@ -1,10 +1,5 @@
-/*
- * Copyright CVOYA LLC.
- *
- * This source code is proprietary and confidential.
- * Unauthorized copying, modification, distribution, or use of this file,
- * via any medium, is strictly prohibited without the prior written consent of CVOYA LLC.
- */
+// Copyright CVOYA LLC. Licensed under the Business Source License 1.1.
+// See LICENSE.md in the project root for full license terms.
 
 namespace Cvoya.Spring.Packages.SoftwareEngineering.Workflows.Activities;
 

--- a/packages/software-engineering/workflows/software-dev-cycle/SoftwareDevCycle/Activities/ReviewActivity.cs
+++ b/packages/software-engineering/workflows/software-dev-cycle/SoftwareDevCycle/Activities/ReviewActivity.cs
@@ -1,10 +1,5 @@
-/*
- * Copyright CVOYA LLC.
- *
- * This source code is proprietary and confidential.
- * Unauthorized copying, modification, distribution, or use of this file,
- * via any medium, is strictly prohibited without the prior written consent of CVOYA LLC.
- */
+// Copyright CVOYA LLC. Licensed under the Business Source License 1.1.
+// See LICENSE.md in the project root for full license terms.
 
 namespace Cvoya.Spring.Packages.SoftwareEngineering.Workflows.Activities;
 

--- a/packages/software-engineering/workflows/software-dev-cycle/SoftwareDevCycle/Activities/TriageActivity.cs
+++ b/packages/software-engineering/workflows/software-dev-cycle/SoftwareDevCycle/Activities/TriageActivity.cs
@@ -1,10 +1,5 @@
-/*
- * Copyright CVOYA LLC.
- *
- * This source code is proprietary and confidential.
- * Unauthorized copying, modification, distribution, or use of this file,
- * via any medium, is strictly prohibited without the prior written consent of CVOYA LLC.
- */
+// Copyright CVOYA LLC. Licensed under the Business Source License 1.1.
+// See LICENSE.md in the project root for full license terms.
 
 namespace Cvoya.Spring.Packages.SoftwareEngineering.Workflows.Activities;
 

--- a/packages/software-engineering/workflows/software-dev-cycle/SoftwareDevCycle/Models/DevCycleModels.cs
+++ b/packages/software-engineering/workflows/software-dev-cycle/SoftwareDevCycle/Models/DevCycleModels.cs
@@ -1,10 +1,5 @@
-/*
- * Copyright CVOYA LLC.
- *
- * This source code is proprietary and confidential.
- * Unauthorized copying, modification, distribution, or use of this file,
- * via any medium, is strictly prohibited without the prior written consent of CVOYA LLC.
- */
+// Copyright CVOYA LLC. Licensed under the Business Source License 1.1.
+// See LICENSE.md in the project root for full license terms.
 
 namespace Cvoya.Spring.Packages.SoftwareEngineering.Workflows.Models;
 

--- a/packages/software-engineering/workflows/software-dev-cycle/SoftwareDevCycle/Program.cs
+++ b/packages/software-engineering/workflows/software-dev-cycle/SoftwareDevCycle/Program.cs
@@ -1,10 +1,5 @@
-/*
- * Copyright CVOYA LLC.
- *
- * This source code is proprietary and confidential.
- * Unauthorized copying, modification, distribution, or use of this file,
- * via any medium, is strictly prohibited without the prior written consent of CVOYA LLC.
- */
+// Copyright CVOYA LLC. Licensed under the Business Source License 1.1.
+// See LICENSE.md in the project root for full license terms.
 
 using Cvoya.Spring.Packages.SoftwareEngineering.Workflows;
 using Cvoya.Spring.Packages.SoftwareEngineering.Workflows.Activities;

--- a/packages/software-engineering/workflows/software-dev-cycle/SoftwareDevCycle/SoftwareDevCycleWorkflow.cs
+++ b/packages/software-engineering/workflows/software-dev-cycle/SoftwareDevCycle/SoftwareDevCycleWorkflow.cs
@@ -1,10 +1,5 @@
-/*
- * Copyright CVOYA LLC.
- *
- * This source code is proprietary and confidential.
- * Unauthorized copying, modification, distribution, or use of this file,
- * via any medium, is strictly prohibited without the prior written consent of CVOYA LLC.
- */
+// Copyright CVOYA LLC. Licensed under the Business Source License 1.1.
+// See LICENSE.md in the project root for full license terms.
 
 namespace Cvoya.Spring.Packages.SoftwareEngineering.Workflows;
 

--- a/src/Cvoya.Spring.A2A/A2AProtocolStub.cs
+++ b/src/Cvoya.Spring.A2A/A2AProtocolStub.cs
@@ -1,10 +1,5 @@
-/*
- * Copyright CVOYA LLC.
- *
- * This source code is proprietary and confidential.
- * Unauthorized copying, modification, distribution, or use of this file,
- * via any medium, is strictly prohibited without the prior written consent of CVOYA LLC.
- */
+// Copyright CVOYA LLC. Licensed under the Business Source License 1.1.
+// See LICENSE.md in the project root for full license terms.
 
 namespace Cvoya.Spring.A2A;
 

--- a/src/Cvoya.Spring.Cli/AddressParser.cs
+++ b/src/Cvoya.Spring.Cli/AddressParser.cs
@@ -1,10 +1,5 @@
-/*
- * Copyright CVOYA LLC.
- *
- * This source code is proprietary and confidential.
- * Unauthorized copying, modification, distribution, or use of this file,
- * via any medium, is strictly prohibited without the prior written consent of CVOYA LLC.
- */
+// Copyright CVOYA LLC. Licensed under the Business Source License 1.1.
+// See LICENSE.md in the project root for full license terms.
 
 namespace Cvoya.Spring.Cli;
 

--- a/src/Cvoya.Spring.Cli/ApiClient.cs
+++ b/src/Cvoya.Spring.Cli/ApiClient.cs
@@ -1,10 +1,5 @@
-/*
- * Copyright CVOYA LLC.
- *
- * This source code is proprietary and confidential.
- * Unauthorized copying, modification, distribution, or use of this file,
- * via any medium, is strictly prohibited without the prior written consent of CVOYA LLC.
- */
+// Copyright CVOYA LLC. Licensed under the Business Source License 1.1.
+// See LICENSE.md in the project root for full license terms.
 
 namespace Cvoya.Spring.Cli;
 

--- a/src/Cvoya.Spring.Cli/CliConfig.cs
+++ b/src/Cvoya.Spring.Cli/CliConfig.cs
@@ -1,10 +1,5 @@
-/*
- * Copyright CVOYA LLC.
- *
- * This source code is proprietary and confidential.
- * Unauthorized copying, modification, distribution, or use of this file,
- * via any medium, is strictly prohibited without the prior written consent of CVOYA LLC.
- */
+// Copyright CVOYA LLC. Licensed under the Business Source License 1.1.
+// See LICENSE.md in the project root for full license terms.
 
 namespace Cvoya.Spring.Cli;
 

--- a/src/Cvoya.Spring.Cli/ClientFactory.cs
+++ b/src/Cvoya.Spring.Cli/ClientFactory.cs
@@ -1,10 +1,5 @@
-/*
- * Copyright CVOYA LLC.
- *
- * This source code is proprietary and confidential.
- * Unauthorized copying, modification, distribution, or use of this file,
- * via any medium, is strictly prohibited without the prior written consent of CVOYA LLC.
- */
+// Copyright CVOYA LLC. Licensed under the Business Source License 1.1.
+// See LICENSE.md in the project root for full license terms.
 
 namespace Cvoya.Spring.Cli;
 

--- a/src/Cvoya.Spring.Cli/Commands/AgentCommand.cs
+++ b/src/Cvoya.Spring.Cli/Commands/AgentCommand.cs
@@ -1,10 +1,5 @@
-/*
- * Copyright CVOYA LLC.
- *
- * This source code is proprietary and confidential.
- * Unauthorized copying, modification, distribution, or use of this file,
- * via any medium, is strictly prohibited without the prior written consent of CVOYA LLC.
- */
+// Copyright CVOYA LLC. Licensed under the Business Source License 1.1.
+// See LICENSE.md in the project root for full license terms.
 
 namespace Cvoya.Spring.Cli.Commands;
 

--- a/src/Cvoya.Spring.Cli/Commands/ApplyCommand.cs
+++ b/src/Cvoya.Spring.Cli/Commands/ApplyCommand.cs
@@ -1,10 +1,5 @@
-/*
- * Copyright CVOYA LLC.
- *
- * This source code is proprietary and confidential.
- * Unauthorized copying, modification, distribution, or use of this file,
- * via any medium, is strictly prohibited without the prior written consent of CVOYA LLC.
- */
+// Copyright CVOYA LLC. Licensed under the Business Source License 1.1.
+// See LICENSE.md in the project root for full license terms.
 
 namespace Cvoya.Spring.Cli.Commands;
 

--- a/src/Cvoya.Spring.Cli/Commands/AuthCommand.cs
+++ b/src/Cvoya.Spring.Cli/Commands/AuthCommand.cs
@@ -1,10 +1,5 @@
-/*
- * Copyright CVOYA LLC.
- *
- * This source code is proprietary and confidential.
- * Unauthorized copying, modification, distribution, or use of this file,
- * via any medium, is strictly prohibited without the prior written consent of CVOYA LLC.
- */
+// Copyright CVOYA LLC. Licensed under the Business Source License 1.1.
+// See LICENSE.md in the project root for full license terms.
 
 namespace Cvoya.Spring.Cli.Commands;
 

--- a/src/Cvoya.Spring.Cli/Commands/MessageCommand.cs
+++ b/src/Cvoya.Spring.Cli/Commands/MessageCommand.cs
@@ -1,10 +1,5 @@
-/*
- * Copyright CVOYA LLC.
- *
- * This source code is proprietary and confidential.
- * Unauthorized copying, modification, distribution, or use of this file,
- * via any medium, is strictly prohibited without the prior written consent of CVOYA LLC.
- */
+// Copyright CVOYA LLC. Licensed under the Business Source License 1.1.
+// See LICENSE.md in the project root for full license terms.
 
 namespace Cvoya.Spring.Cli.Commands;
 

--- a/src/Cvoya.Spring.Cli/Commands/UnitCommand.cs
+++ b/src/Cvoya.Spring.Cli/Commands/UnitCommand.cs
@@ -1,10 +1,5 @@
-/*
- * Copyright CVOYA LLC.
- *
- * This source code is proprietary and confidential.
- * Unauthorized copying, modification, distribution, or use of this file,
- * via any medium, is strictly prohibited without the prior written consent of CVOYA LLC.
- */
+// Copyright CVOYA LLC. Licensed under the Business Source License 1.1.
+// See LICENSE.md in the project root for full license terms.
 
 namespace Cvoya.Spring.Cli.Commands;
 

--- a/src/Cvoya.Spring.Cli/Output/OutputFormatter.cs
+++ b/src/Cvoya.Spring.Cli/Output/OutputFormatter.cs
@@ -1,10 +1,5 @@
-/*
- * Copyright CVOYA LLC.
- *
- * This source code is proprietary and confidential.
- * Unauthorized copying, modification, distribution, or use of this file,
- * via any medium, is strictly prohibited without the prior written consent of CVOYA LLC.
- */
+// Copyright CVOYA LLC. Licensed under the Business Source License 1.1.
+// See LICENSE.md in the project root for full license terms.
 
 namespace Cvoya.Spring.Cli.Output;
 

--- a/src/Cvoya.Spring.Cli/Program.cs
+++ b/src/Cvoya.Spring.Cli/Program.cs
@@ -1,10 +1,5 @@
-/*
- * Copyright CVOYA LLC.
- *
- * This source code is proprietary and confidential.
- * Unauthorized copying, modification, distribution, or use of this file,
- * via any medium, is strictly prohibited without the prior written consent of CVOYA LLC.
- */
+// Copyright CVOYA LLC. Licensed under the Business Source License 1.1.
+// See LICENSE.md in the project root for full license terms.
 
 namespace Cvoya.Spring.Cli;
 

--- a/src/Cvoya.Spring.Connector.GitHub/Auth/GitHubAppAuth.cs
+++ b/src/Cvoya.Spring.Connector.GitHub/Auth/GitHubAppAuth.cs
@@ -1,10 +1,5 @@
-/*
- * Copyright CVOYA LLC.
- *
- * This source code is proprietary and confidential.
- * Unauthorized copying, modification, distribution, or use of this file,
- * via any medium, is strictly prohibited without the prior written consent of CVOYA LLC.
- */
+// Copyright CVOYA LLC. Licensed under the Business Source License 1.1.
+// See LICENSE.md in the project root for full license terms.
 
 namespace Cvoya.Spring.Connector.GitHub.Auth;
 

--- a/src/Cvoya.Spring.Connector.GitHub/Auth/GitHubConnectorOptions.cs
+++ b/src/Cvoya.Spring.Connector.GitHub/Auth/GitHubConnectorOptions.cs
@@ -1,10 +1,5 @@
-/*
- * Copyright CVOYA LLC.
- *
- * This source code is proprietary and confidential.
- * Unauthorized copying, modification, distribution, or use of this file,
- * via any medium, is strictly prohibited without the prior written consent of CVOYA LLC.
- */
+// Copyright CVOYA LLC. Licensed under the Business Source License 1.1.
+// See LICENSE.md in the project root for full license terms.
 
 namespace Cvoya.Spring.Connector.GitHub.Auth;
 

--- a/src/Cvoya.Spring.Connector.GitHub/GitHubConnector.cs
+++ b/src/Cvoya.Spring.Connector.GitHub/GitHubConnector.cs
@@ -1,10 +1,5 @@
-/*
- * Copyright CVOYA LLC.
- *
- * This source code is proprietary and confidential.
- * Unauthorized copying, modification, distribution, or use of this file,
- * via any medium, is strictly prohibited without the prior written consent of CVOYA LLC.
- */
+// Copyright CVOYA LLC. Licensed under the Business Source License 1.1.
+// See LICENSE.md in the project root for full license terms.
 
 namespace Cvoya.Spring.Connector.GitHub;
 

--- a/src/Cvoya.Spring.Connector.GitHub/GitHubSkillRegistry.cs
+++ b/src/Cvoya.Spring.Connector.GitHub/GitHubSkillRegistry.cs
@@ -1,10 +1,5 @@
-/*
- * Copyright CVOYA LLC.
- *
- * This source code is proprietary and confidential.
- * Unauthorized copying, modification, distribution, or use of this file,
- * via any medium, is strictly prohibited without the prior written consent of CVOYA LLC.
- */
+// Copyright CVOYA LLC. Licensed under the Business Source License 1.1.
+// See LICENSE.md in the project root for full license terms.
 
 namespace Cvoya.Spring.Connector.GitHub;
 

--- a/src/Cvoya.Spring.Connector.GitHub/Skills/CommentSkill.cs
+++ b/src/Cvoya.Spring.Connector.GitHub/Skills/CommentSkill.cs
@@ -1,10 +1,5 @@
-/*
- * Copyright CVOYA LLC.
- *
- * This source code is proprietary and confidential.
- * Unauthorized copying, modification, distribution, or use of this file,
- * via any medium, is strictly prohibited without the prior written consent of CVOYA LLC.
- */
+// Copyright CVOYA LLC. Licensed under the Business Source License 1.1.
+// See LICENSE.md in the project root for full license terms.
 
 namespace Cvoya.Spring.Connector.GitHub.Skills;
 

--- a/src/Cvoya.Spring.Connector.GitHub/Skills/CreateBranchSkill.cs
+++ b/src/Cvoya.Spring.Connector.GitHub/Skills/CreateBranchSkill.cs
@@ -1,10 +1,5 @@
-/*
- * Copyright CVOYA LLC.
- *
- * This source code is proprietary and confidential.
- * Unauthorized copying, modification, distribution, or use of this file,
- * via any medium, is strictly prohibited without the prior written consent of CVOYA LLC.
- */
+// Copyright CVOYA LLC. Licensed under the Business Source License 1.1.
+// See LICENSE.md in the project root for full license terms.
 
 namespace Cvoya.Spring.Connector.GitHub.Skills;
 

--- a/src/Cvoya.Spring.Connector.GitHub/Skills/CreatePullRequestSkill.cs
+++ b/src/Cvoya.Spring.Connector.GitHub/Skills/CreatePullRequestSkill.cs
@@ -1,10 +1,5 @@
-/*
- * Copyright CVOYA LLC.
- *
- * This source code is proprietary and confidential.
- * Unauthorized copying, modification, distribution, or use of this file,
- * via any medium, is strictly prohibited without the prior written consent of CVOYA LLC.
- */
+// Copyright CVOYA LLC. Licensed under the Business Source License 1.1.
+// See LICENSE.md in the project root for full license terms.
 
 namespace Cvoya.Spring.Connector.GitHub.Skills;
 

--- a/src/Cvoya.Spring.Connector.GitHub/Skills/GetIssueDetailsSkill.cs
+++ b/src/Cvoya.Spring.Connector.GitHub/Skills/GetIssueDetailsSkill.cs
@@ -1,10 +1,5 @@
-/*
- * Copyright CVOYA LLC.
- *
- * This source code is proprietary and confidential.
- * Unauthorized copying, modification, distribution, or use of this file,
- * via any medium, is strictly prohibited without the prior written consent of CVOYA LLC.
- */
+// Copyright CVOYA LLC. Licensed under the Business Source License 1.1.
+// See LICENSE.md in the project root for full license terms.
 
 namespace Cvoya.Spring.Connector.GitHub.Skills;
 

--- a/src/Cvoya.Spring.Connector.GitHub/Skills/GetPullRequestDiffSkill.cs
+++ b/src/Cvoya.Spring.Connector.GitHub/Skills/GetPullRequestDiffSkill.cs
@@ -1,10 +1,5 @@
-/*
- * Copyright CVOYA LLC.
- *
- * This source code is proprietary and confidential.
- * Unauthorized copying, modification, distribution, or use of this file,
- * via any medium, is strictly prohibited without the prior written consent of CVOYA LLC.
- */
+// Copyright CVOYA LLC. Licensed under the Business Source License 1.1.
+// See LICENSE.md in the project root for full license terms.
 
 namespace Cvoya.Spring.Connector.GitHub.Skills;
 

--- a/src/Cvoya.Spring.Connector.GitHub/Skills/ListFilesSkill.cs
+++ b/src/Cvoya.Spring.Connector.GitHub/Skills/ListFilesSkill.cs
@@ -1,10 +1,5 @@
-/*
- * Copyright CVOYA LLC.
- *
- * This source code is proprietary and confidential.
- * Unauthorized copying, modification, distribution, or use of this file,
- * via any medium, is strictly prohibited without the prior written consent of CVOYA LLC.
- */
+// Copyright CVOYA LLC. Licensed under the Business Source License 1.1.
+// See LICENSE.md in the project root for full license terms.
 
 namespace Cvoya.Spring.Connector.GitHub.Skills;
 

--- a/src/Cvoya.Spring.Connector.GitHub/Skills/ManageLabelsSkill.cs
+++ b/src/Cvoya.Spring.Connector.GitHub/Skills/ManageLabelsSkill.cs
@@ -1,10 +1,5 @@
-/*
- * Copyright CVOYA LLC.
- *
- * This source code is proprietary and confidential.
- * Unauthorized copying, modification, distribution, or use of this file,
- * via any medium, is strictly prohibited without the prior written consent of CVOYA LLC.
- */
+// Copyright CVOYA LLC. Licensed under the Business Source License 1.1.
+// See LICENSE.md in the project root for full license terms.
 
 namespace Cvoya.Spring.Connector.GitHub.Skills;
 

--- a/src/Cvoya.Spring.Connector.GitHub/Skills/ReadFileSkill.cs
+++ b/src/Cvoya.Spring.Connector.GitHub/Skills/ReadFileSkill.cs
@@ -1,10 +1,5 @@
-/*
- * Copyright CVOYA LLC.
- *
- * This source code is proprietary and confidential.
- * Unauthorized copying, modification, distribution, or use of this file,
- * via any medium, is strictly prohibited without the prior written consent of CVOYA LLC.
- */
+// Copyright CVOYA LLC. Licensed under the Business Source License 1.1.
+// See LICENSE.md in the project root for full license terms.
 
 namespace Cvoya.Spring.Connector.GitHub.Skills;
 

--- a/src/Cvoya.Spring.Connector.GitHub/Webhooks/GitHubWebhookHandler.cs
+++ b/src/Cvoya.Spring.Connector.GitHub/Webhooks/GitHubWebhookHandler.cs
@@ -1,10 +1,5 @@
-/*
- * Copyright CVOYA LLC.
- *
- * This source code is proprietary and confidential.
- * Unauthorized copying, modification, distribution, or use of this file,
- * via any medium, is strictly prohibited without the prior written consent of CVOYA LLC.
- */
+// Copyright CVOYA LLC. Licensed under the Business Source License 1.1.
+// See LICENSE.md in the project root for full license terms.
 
 namespace Cvoya.Spring.Connector.GitHub.Webhooks;
 

--- a/src/Cvoya.Spring.Connector.GitHub/Webhooks/WebhookSignatureValidator.cs
+++ b/src/Cvoya.Spring.Connector.GitHub/Webhooks/WebhookSignatureValidator.cs
@@ -1,10 +1,5 @@
-/*
- * Copyright CVOYA LLC.
- *
- * This source code is proprietary and confidential.
- * Unauthorized copying, modification, distribution, or use of this file,
- * via any medium, is strictly prohibited without the prior written consent of CVOYA LLC.
- */
+// Copyright CVOYA LLC. Licensed under the Business Source License 1.1.
+// See LICENSE.md in the project root for full license terms.
 
 namespace Cvoya.Spring.Connector.GitHub.Webhooks;
 

--- a/src/Cvoya.Spring.Core/Capabilities/ActivityEvent.cs
+++ b/src/Cvoya.Spring.Core/Capabilities/ActivityEvent.cs
@@ -1,10 +1,5 @@
-/*
- * Copyright CVOYA LLC.
- *
- * This source code is proprietary and confidential.
- * Unauthorized copying, modification, distribution, or use of this file,
- * via any medium, is strictly prohibited without the prior written consent of CVOYA LLC.
- */
+// Copyright CVOYA LLC. Licensed under the Business Source License 1.1.
+// See LICENSE.md in the project root for full license terms.
 
 namespace Cvoya.Spring.Core.Capabilities;
 

--- a/src/Cvoya.Spring.Core/Capabilities/ExpertiseDomain.cs
+++ b/src/Cvoya.Spring.Core/Capabilities/ExpertiseDomain.cs
@@ -1,10 +1,5 @@
-/*
- * Copyright CVOYA LLC.
- *
- * This source code is proprietary and confidential.
- * Unauthorized copying, modification, distribution, or use of this file,
- * via any medium, is strictly prohibited without the prior written consent of CVOYA LLC.
- */
+// Copyright CVOYA LLC. Licensed under the Business Source License 1.1.
+// See LICENSE.md in the project root for full license terms.
 
 namespace Cvoya.Spring.Core.Capabilities;
 

--- a/src/Cvoya.Spring.Core/Capabilities/ExpertiseProfile.cs
+++ b/src/Cvoya.Spring.Core/Capabilities/ExpertiseProfile.cs
@@ -1,10 +1,5 @@
-/*
- * Copyright CVOYA LLC.
- *
- * This source code is proprietary and confidential.
- * Unauthorized copying, modification, distribution, or use of this file,
- * via any medium, is strictly prohibited without the prior written consent of CVOYA LLC.
- */
+// Copyright CVOYA LLC. Licensed under the Business Source License 1.1.
+// See LICENSE.md in the project root for full license terms.
 
 namespace Cvoya.Spring.Core.Capabilities;
 

--- a/src/Cvoya.Spring.Core/Capabilities/IActivityObservable.cs
+++ b/src/Cvoya.Spring.Core/Capabilities/IActivityObservable.cs
@@ -1,10 +1,5 @@
-/*
- * Copyright CVOYA LLC.
- *
- * This source code is proprietary and confidential.
- * Unauthorized copying, modification, distribution, or use of this file,
- * via any medium, is strictly prohibited without the prior written consent of CVOYA LLC.
- */
+// Copyright CVOYA LLC. Licensed under the Business Source License 1.1.
+// See LICENSE.md in the project root for full license terms.
 
 namespace Cvoya.Spring.Core.Capabilities;
 

--- a/src/Cvoya.Spring.Core/Capabilities/ICapabilityProvider.cs
+++ b/src/Cvoya.Spring.Core/Capabilities/ICapabilityProvider.cs
@@ -1,10 +1,5 @@
-/*
- * Copyright CVOYA LLC.
- *
- * This source code is proprietary and confidential.
- * Unauthorized copying, modification, distribution, or use of this file,
- * via any medium, is strictly prohibited without the prior written consent of CVOYA LLC.
- */
+// Copyright CVOYA LLC. Licensed under the Business Source License 1.1.
+// See LICENSE.md in the project root for full license terms.
 
 namespace Cvoya.Spring.Core.Capabilities;
 

--- a/src/Cvoya.Spring.Core/Capabilities/IExpertiseProvider.cs
+++ b/src/Cvoya.Spring.Core/Capabilities/IExpertiseProvider.cs
@@ -1,10 +1,5 @@
-/*
- * Copyright CVOYA LLC.
- *
- * This source code is proprietary and confidential.
- * Unauthorized copying, modification, distribution, or use of this file,
- * via any medium, is strictly prohibited without the prior written consent of CVOYA LLC.
- */
+// Copyright CVOYA LLC. Licensed under the Business Source License 1.1.
+// See LICENSE.md in the project root for full license terms.
 
 namespace Cvoya.Spring.Core.Capabilities;
 

--- a/src/Cvoya.Spring.Core/Directory/DirectoryEntry.cs
+++ b/src/Cvoya.Spring.Core/Directory/DirectoryEntry.cs
@@ -1,10 +1,5 @@
-/*
- * Copyright CVOYA LLC.
- *
- * This source code is proprietary and confidential.
- * Unauthorized copying, modification, distribution, or use of this file,
- * via any medium, is strictly prohibited without the prior written consent of CVOYA LLC.
- */
+// Copyright CVOYA LLC. Licensed under the Business Source License 1.1.
+// See LICENSE.md in the project root for full license terms.
 
 namespace Cvoya.Spring.Core.Directory;
 

--- a/src/Cvoya.Spring.Core/Directory/IDirectoryService.cs
+++ b/src/Cvoya.Spring.Core/Directory/IDirectoryService.cs
@@ -1,10 +1,5 @@
-/*
- * Copyright CVOYA LLC.
- *
- * This source code is proprietary and confidential.
- * Unauthorized copying, modification, distribution, or use of this file,
- * via any medium, is strictly prohibited without the prior written consent of CVOYA LLC.
- */
+// Copyright CVOYA LLC. Licensed under the Business Source License 1.1.
+// See LICENSE.md in the project root for full license terms.
 
 namespace Cvoya.Spring.Core.Directory;
 

--- a/src/Cvoya.Spring.Core/Execution/ExecutionMode.cs
+++ b/src/Cvoya.Spring.Core/Execution/ExecutionMode.cs
@@ -1,10 +1,5 @@
-/*
- * Copyright CVOYA LLC.
- *
- * This source code is proprietary and confidential.
- * Unauthorized copying, modification, distribution, or use of this file,
- * via any medium, is strictly prohibited without the prior written consent of CVOYA LLC.
- */
+// Copyright CVOYA LLC. Licensed under the Business Source License 1.1.
+// See LICENSE.md in the project root for full license terms.
 
 namespace Cvoya.Spring.Core.Execution;
 

--- a/src/Cvoya.Spring.Core/Execution/IAiProvider.cs
+++ b/src/Cvoya.Spring.Core/Execution/IAiProvider.cs
@@ -1,10 +1,5 @@
-/*
- * Copyright CVOYA LLC.
- *
- * This source code is proprietary and confidential.
- * Unauthorized copying, modification, distribution, or use of this file,
- * via any medium, is strictly prohibited without the prior written consent of CVOYA LLC.
- */
+// Copyright CVOYA LLC. Licensed under the Business Source License 1.1.
+// See LICENSE.md in the project root for full license terms.
 
 namespace Cvoya.Spring.Core.Execution;
 

--- a/src/Cvoya.Spring.Core/Execution/IContainerRuntime.cs
+++ b/src/Cvoya.Spring.Core/Execution/IContainerRuntime.cs
@@ -1,10 +1,5 @@
-/*
- * Copyright CVOYA LLC.
- *
- * This source code is proprietary and confidential.
- * Unauthorized copying, modification, distribution, or use of this file,
- * via any medium, is strictly prohibited without the prior written consent of CVOYA LLC.
- */
+// Copyright CVOYA LLC. Licensed under the Business Source License 1.1.
+// See LICENSE.md in the project root for full license terms.
 
 namespace Cvoya.Spring.Core.Execution;
 

--- a/src/Cvoya.Spring.Core/Execution/IDaprSidecarManager.cs
+++ b/src/Cvoya.Spring.Core/Execution/IDaprSidecarManager.cs
@@ -1,10 +1,5 @@
-/*
- * Copyright CVOYA LLC.
- *
- * This source code is proprietary and confidential.
- * Unauthorized copying, modification, distribution, or use of this file,
- * via any medium, is strictly prohibited without the prior written consent of CVOYA LLC.
- */
+// Copyright CVOYA LLC. Licensed under the Business Source License 1.1.
+// See LICENSE.md in the project root for full license terms.
 
 namespace Cvoya.Spring.Core.Execution;
 

--- a/src/Cvoya.Spring.Core/Execution/IExecutionDispatcher.cs
+++ b/src/Cvoya.Spring.Core/Execution/IExecutionDispatcher.cs
@@ -1,10 +1,5 @@
-/*
- * Copyright CVOYA LLC.
- *
- * This source code is proprietary and confidential.
- * Unauthorized copying, modification, distribution, or use of this file,
- * via any medium, is strictly prohibited without the prior written consent of CVOYA LLC.
- */
+// Copyright CVOYA LLC. Licensed under the Business Source License 1.1.
+// See LICENSE.md in the project root for full license terms.
 
 namespace Cvoya.Spring.Core.Execution;
 

--- a/src/Cvoya.Spring.Core/Execution/IPlatformPromptProvider.cs
+++ b/src/Cvoya.Spring.Core/Execution/IPlatformPromptProvider.cs
@@ -1,10 +1,5 @@
-/*
- * Copyright CVOYA LLC.
- *
- * This source code is proprietary and confidential.
- * Unauthorized copying, modification, distribution, or use of this file,
- * via any medium, is strictly prohibited without the prior written consent of CVOYA LLC.
- */
+// Copyright CVOYA LLC. Licensed under the Business Source License 1.1.
+// See LICENSE.md in the project root for full license terms.
 
 namespace Cvoya.Spring.Core.Execution;
 

--- a/src/Cvoya.Spring.Core/Execution/IPromptAssembler.cs
+++ b/src/Cvoya.Spring.Core/Execution/IPromptAssembler.cs
@@ -1,10 +1,5 @@
-/*
- * Copyright CVOYA LLC.
- *
- * This source code is proprietary and confidential.
- * Unauthorized copying, modification, distribution, or use of this file,
- * via any medium, is strictly prohibited without the prior written consent of CVOYA LLC.
- */
+// Copyright CVOYA LLC. Licensed under the Business Source License 1.1.
+// See LICENSE.md in the project root for full license terms.
 
 namespace Cvoya.Spring.Core.Execution;
 

--- a/src/Cvoya.Spring.Core/IAgent.cs
+++ b/src/Cvoya.Spring.Core/IAgent.cs
@@ -1,10 +1,5 @@
-/*
- * Copyright CVOYA LLC.
- *
- * This source code is proprietary and confidential.
- * Unauthorized copying, modification, distribution, or use of this file,
- * via any medium, is strictly prohibited without the prior written consent of CVOYA LLC.
- */
+// Copyright CVOYA LLC. Licensed under the Business Source License 1.1.
+// See LICENSE.md in the project root for full license terms.
 
 namespace Cvoya.Spring.Core;
 

--- a/src/Cvoya.Spring.Core/Messaging/Address.cs
+++ b/src/Cvoya.Spring.Core/Messaging/Address.cs
@@ -1,10 +1,5 @@
-/*
- * Copyright CVOYA LLC.
- *
- * This source code is proprietary and confidential.
- * Unauthorized copying, modification, distribution, or use of this file,
- * via any medium, is strictly prohibited without the prior written consent of CVOYA LLC.
- */
+// Copyright CVOYA LLC. Licensed under the Business Source License 1.1.
+// See LICENSE.md in the project root for full license terms.
 
 namespace Cvoya.Spring.Core.Messaging;
 

--- a/src/Cvoya.Spring.Core/Messaging/IAddressable.cs
+++ b/src/Cvoya.Spring.Core/Messaging/IAddressable.cs
@@ -1,10 +1,5 @@
-/*
- * Copyright CVOYA LLC.
- *
- * This source code is proprietary and confidential.
- * Unauthorized copying, modification, distribution, or use of this file,
- * via any medium, is strictly prohibited without the prior written consent of CVOYA LLC.
- */
+// Copyright CVOYA LLC. Licensed under the Business Source License 1.1.
+// See LICENSE.md in the project root for full license terms.
 
 namespace Cvoya.Spring.Core.Messaging;
 

--- a/src/Cvoya.Spring.Core/Messaging/IMessageReceiver.cs
+++ b/src/Cvoya.Spring.Core/Messaging/IMessageReceiver.cs
@@ -1,10 +1,5 @@
-/*
- * Copyright CVOYA LLC.
- *
- * This source code is proprietary and confidential.
- * Unauthorized copying, modification, distribution, or use of this file,
- * via any medium, is strictly prohibited without the prior written consent of CVOYA LLC.
- */
+// Copyright CVOYA LLC. Licensed under the Business Source License 1.1.
+// See LICENSE.md in the project root for full license terms.
 
 namespace Cvoya.Spring.Core.Messaging;
 

--- a/src/Cvoya.Spring.Core/Messaging/Message.cs
+++ b/src/Cvoya.Spring.Core/Messaging/Message.cs
@@ -1,10 +1,5 @@
-/*
- * Copyright CVOYA LLC.
- *
- * This source code is proprietary and confidential.
- * Unauthorized copying, modification, distribution, or use of this file,
- * via any medium, is strictly prohibited without the prior written consent of CVOYA LLC.
- */
+// Copyright CVOYA LLC. Licensed under the Business Source License 1.1.
+// See LICENSE.md in the project root for full license terms.
 
 namespace Cvoya.Spring.Core.Messaging;
 

--- a/src/Cvoya.Spring.Core/Messaging/MessageType.cs
+++ b/src/Cvoya.Spring.Core/Messaging/MessageType.cs
@@ -1,10 +1,5 @@
-/*
- * Copyright CVOYA LLC.
- *
- * This source code is proprietary and confidential.
- * Unauthorized copying, modification, distribution, or use of this file,
- * via any medium, is strictly prohibited without the prior written consent of CVOYA LLC.
- */
+// Copyright CVOYA LLC. Licensed under the Business Source License 1.1.
+// See LICENSE.md in the project root for full license terms.
 
 namespace Cvoya.Spring.Core.Messaging;
 

--- a/src/Cvoya.Spring.Core/Orchestration/IOrchestrationStrategy.cs
+++ b/src/Cvoya.Spring.Core/Orchestration/IOrchestrationStrategy.cs
@@ -1,10 +1,5 @@
-/*
- * Copyright CVOYA LLC.
- *
- * This source code is proprietary and confidential.
- * Unauthorized copying, modification, distribution, or use of this file,
- * via any medium, is strictly prohibited without the prior written consent of CVOYA LLC.
- */
+// Copyright CVOYA LLC. Licensed under the Business Source License 1.1.
+// See LICENSE.md in the project root for full license terms.
 
 namespace Cvoya.Spring.Core.Orchestration;
 

--- a/src/Cvoya.Spring.Core/Orchestration/IUnitContext.cs
+++ b/src/Cvoya.Spring.Core/Orchestration/IUnitContext.cs
@@ -1,10 +1,5 @@
-/*
- * Copyright CVOYA LLC.
- *
- * This source code is proprietary and confidential.
- * Unauthorized copying, modification, distribution, or use of this file,
- * via any medium, is strictly prohibited without the prior written consent of CVOYA LLC.
- */
+// Copyright CVOYA LLC. Licensed under the Business Source License 1.1.
+// See LICENSE.md in the project root for full license terms.
 
 namespace Cvoya.Spring.Core.Orchestration;
 

--- a/src/Cvoya.Spring.Core/Result.cs
+++ b/src/Cvoya.Spring.Core/Result.cs
@@ -1,10 +1,5 @@
-/*
- * Copyright CVOYA LLC.
- *
- * This source code is proprietary and confidential.
- * Unauthorized copying, modification, distribution, or use of this file,
- * via any medium, is strictly prohibited without the prior written consent of CVOYA LLC.
- */
+// Copyright CVOYA LLC. Licensed under the Business Source License 1.1.
+// See LICENSE.md in the project root for full license terms.
 
 namespace Cvoya.Spring.Core;
 

--- a/src/Cvoya.Spring.Core/Skills/Skill.cs
+++ b/src/Cvoya.Spring.Core/Skills/Skill.cs
@@ -1,10 +1,5 @@
-/*
- * Copyright CVOYA LLC.
- *
- * This source code is proprietary and confidential.
- * Unauthorized copying, modification, distribution, or use of this file,
- * via any medium, is strictly prohibited without the prior written consent of CVOYA LLC.
- */
+// Copyright CVOYA LLC. Licensed under the Business Source License 1.1.
+// See LICENSE.md in the project root for full license terms.
 
 namespace Cvoya.Spring.Core.Skills;
 

--- a/src/Cvoya.Spring.Core/Skills/ToolDefinition.cs
+++ b/src/Cvoya.Spring.Core/Skills/ToolDefinition.cs
@@ -1,10 +1,5 @@
-/*
- * Copyright CVOYA LLC.
- *
- * This source code is proprietary and confidential.
- * Unauthorized copying, modification, distribution, or use of this file,
- * via any medium, is strictly prohibited without the prior written consent of CVOYA LLC.
- */
+// Copyright CVOYA LLC. Licensed under the Business Source License 1.1.
+// See LICENSE.md in the project root for full license terms.
 
 namespace Cvoya.Spring.Core.Skills;
 

--- a/src/Cvoya.Spring.Core/SpringException.cs
+++ b/src/Cvoya.Spring.Core/SpringException.cs
@@ -1,10 +1,5 @@
-/*
- * Copyright CVOYA LLC.
- *
- * This source code is proprietary and confidential.
- * Unauthorized copying, modification, distribution, or use of this file,
- * via any medium, is strictly prohibited without the prior written consent of CVOYA LLC.
- */
+// Copyright CVOYA LLC. Licensed under the Business Source License 1.1.
+// See LICENSE.md in the project root for full license terms.
 
 namespace Cvoya.Spring.Core;
 

--- a/src/Cvoya.Spring.Core/State/IStateStore.cs
+++ b/src/Cvoya.Spring.Core/State/IStateStore.cs
@@ -1,10 +1,5 @@
-/*
- * Copyright CVOYA LLC.
- *
- * This source code is proprietary and confidential.
- * Unauthorized copying, modification, distribution, or use of this file,
- * via any medium, is strictly prohibited without the prior written consent of CVOYA LLC.
- */
+// Copyright CVOYA LLC. Licensed under the Business Source License 1.1.
+// See LICENSE.md in the project root for full license terms.
 
 namespace Cvoya.Spring.Core.State;
 

--- a/src/Cvoya.Spring.Core/Tools/IPlatformTool.cs
+++ b/src/Cvoya.Spring.Core/Tools/IPlatformTool.cs
@@ -1,10 +1,5 @@
-/*
- * Copyright CVOYA LLC.
- *
- * This source code is proprietary and confidential.
- * Unauthorized copying, modification, distribution, or use of this file,
- * via any medium, is strictly prohibited without the prior written consent of CVOYA LLC.
- */
+// Copyright CVOYA LLC. Licensed under the Business Source License 1.1.
+// See LICENSE.md in the project root for full license terms.
 
 namespace Cvoya.Spring.Core.Tools;
 

--- a/src/Cvoya.Spring.Dapr/Actors/AgentActor.cs
+++ b/src/Cvoya.Spring.Dapr/Actors/AgentActor.cs
@@ -1,10 +1,5 @@
-/*
- * Copyright CVOYA LLC.
- *
- * This source code is proprietary and confidential.
- * Unauthorized copying, modification, distribution, or use of this file,
- * via any medium, is strictly prohibited without the prior written consent of CVOYA LLC.
- */
+// Copyright CVOYA LLC. Licensed under the Business Source License 1.1.
+// See LICENSE.md in the project root for full license terms.
 
 namespace Cvoya.Spring.Dapr.Actors;
 

--- a/src/Cvoya.Spring.Dapr/Actors/AgentStatus.cs
+++ b/src/Cvoya.Spring.Dapr/Actors/AgentStatus.cs
@@ -1,10 +1,5 @@
-/*
- * Copyright CVOYA LLC.
- *
- * This source code is proprietary and confidential.
- * Unauthorized copying, modification, distribution, or use of this file,
- * via any medium, is strictly prohibited without the prior written consent of CVOYA LLC.
- */
+// Copyright CVOYA LLC. Licensed under the Business Source License 1.1.
+// See LICENSE.md in the project root for full license terms.
 
 namespace Cvoya.Spring.Dapr.Actors;
 

--- a/src/Cvoya.Spring.Dapr/Actors/ConnectionStatus.cs
+++ b/src/Cvoya.Spring.Dapr/Actors/ConnectionStatus.cs
@@ -1,10 +1,5 @@
-/*
- * Copyright CVOYA LLC.
- *
- * This source code is proprietary and confidential.
- * Unauthorized copying, modification, distribution, or use of this file,
- * via any medium, is strictly prohibited without the prior written consent of CVOYA LLC.
- */
+// Copyright CVOYA LLC. Licensed under the Business Source License 1.1.
+// See LICENSE.md in the project root for full license terms.
 
 namespace Cvoya.Spring.Dapr.Actors;
 

--- a/src/Cvoya.Spring.Dapr/Actors/ConnectorActor.cs
+++ b/src/Cvoya.Spring.Dapr/Actors/ConnectorActor.cs
@@ -1,10 +1,5 @@
-/*
- * Copyright CVOYA LLC.
- *
- * This source code is proprietary and confidential.
- * Unauthorized copying, modification, distribution, or use of this file,
- * via any medium, is strictly prohibited without the prior written consent of CVOYA LLC.
- */
+// Copyright CVOYA LLC. Licensed under the Business Source License 1.1.
+// See LICENSE.md in the project root for full license terms.
 
 namespace Cvoya.Spring.Dapr.Actors;
 

--- a/src/Cvoya.Spring.Dapr/Actors/ConversationChannel.cs
+++ b/src/Cvoya.Spring.Dapr/Actors/ConversationChannel.cs
@@ -1,10 +1,5 @@
-/*
- * Copyright CVOYA LLC.
- *
- * This source code is proprietary and confidential.
- * Unauthorized copying, modification, distribution, or use of this file,
- * via any medium, is strictly prohibited without the prior written consent of CVOYA LLC.
- */
+// Copyright CVOYA LLC. Licensed under the Business Source License 1.1.
+// See LICENSE.md in the project root for full license terms.
 
 namespace Cvoya.Spring.Dapr.Actors;
 

--- a/src/Cvoya.Spring.Dapr/Actors/HumanActor.cs
+++ b/src/Cvoya.Spring.Dapr/Actors/HumanActor.cs
@@ -1,10 +1,5 @@
-/*
- * Copyright CVOYA LLC.
- *
- * This source code is proprietary and confidential.
- * Unauthorized copying, modification, distribution, or use of this file,
- * via any medium, is strictly prohibited without the prior written consent of CVOYA LLC.
- */
+// Copyright CVOYA LLC. Licensed under the Business Source License 1.1.
+// See LICENSE.md in the project root for full license terms.
 
 namespace Cvoya.Spring.Dapr.Actors;
 

--- a/src/Cvoya.Spring.Dapr/Actors/IAgentActor.cs
+++ b/src/Cvoya.Spring.Dapr/Actors/IAgentActor.cs
@@ -1,10 +1,5 @@
-/*
- * Copyright CVOYA LLC.
- *
- * This source code is proprietary and confidential.
- * Unauthorized copying, modification, distribution, or use of this file,
- * via any medium, is strictly prohibited without the prior written consent of CVOYA LLC.
- */
+// Copyright CVOYA LLC. Licensed under the Business Source License 1.1.
+// See LICENSE.md in the project root for full license terms.
 
 namespace Cvoya.Spring.Dapr.Actors;
 

--- a/src/Cvoya.Spring.Dapr/Actors/IConnectorActor.cs
+++ b/src/Cvoya.Spring.Dapr/Actors/IConnectorActor.cs
@@ -1,10 +1,5 @@
-/*
- * Copyright CVOYA LLC.
- *
- * This source code is proprietary and confidential.
- * Unauthorized copying, modification, distribution, or use of this file,
- * via any medium, is strictly prohibited without the prior written consent of CVOYA LLC.
- */
+// Copyright CVOYA LLC. Licensed under the Business Source License 1.1.
+// See LICENSE.md in the project root for full license terms.
 
 namespace Cvoya.Spring.Dapr.Actors;
 

--- a/src/Cvoya.Spring.Dapr/Actors/IHumanActor.cs
+++ b/src/Cvoya.Spring.Dapr/Actors/IHumanActor.cs
@@ -1,10 +1,5 @@
-/*
- * Copyright CVOYA LLC.
- *
- * This source code is proprietary and confidential.
- * Unauthorized copying, modification, distribution, or use of this file,
- * via any medium, is strictly prohibited without the prior written consent of CVOYA LLC.
- */
+// Copyright CVOYA LLC. Licensed under the Business Source License 1.1.
+// See LICENSE.md in the project root for full license terms.
 
 namespace Cvoya.Spring.Dapr.Actors;
 

--- a/src/Cvoya.Spring.Dapr/Actors/IUnitActor.cs
+++ b/src/Cvoya.Spring.Dapr/Actors/IUnitActor.cs
@@ -1,10 +1,5 @@
-/*
- * Copyright CVOYA LLC.
- *
- * This source code is proprietary and confidential.
- * Unauthorized copying, modification, distribution, or use of this file,
- * via any medium, is strictly prohibited without the prior written consent of CVOYA LLC.
- */
+// Copyright CVOYA LLC. Licensed under the Business Source License 1.1.
+// See LICENSE.md in the project root for full license terms.
 
 namespace Cvoya.Spring.Dapr.Actors;
 

--- a/src/Cvoya.Spring.Dapr/Actors/PermissionLevel.cs
+++ b/src/Cvoya.Spring.Dapr/Actors/PermissionLevel.cs
@@ -1,10 +1,5 @@
-/*
- * Copyright CVOYA LLC.
- *
- * This source code is proprietary and confidential.
- * Unauthorized copying, modification, distribution, or use of this file,
- * via any medium, is strictly prohibited without the prior written consent of CVOYA LLC.
- */
+// Copyright CVOYA LLC. Licensed under the Business Source License 1.1.
+// See LICENSE.md in the project root for full license terms.
 
 namespace Cvoya.Spring.Dapr.Actors;
 

--- a/src/Cvoya.Spring.Dapr/Actors/StateKeys.cs
+++ b/src/Cvoya.Spring.Dapr/Actors/StateKeys.cs
@@ -1,10 +1,5 @@
-/*
- * Copyright CVOYA LLC.
- *
- * This source code is proprietary and confidential.
- * Unauthorized copying, modification, distribution, or use of this file,
- * via any medium, is strictly prohibited without the prior written consent of CVOYA LLC.
- */
+// Copyright CVOYA LLC. Licensed under the Business Source License 1.1.
+// See LICENSE.md in the project root for full license terms.
 
 namespace Cvoya.Spring.Dapr.Actors;
 

--- a/src/Cvoya.Spring.Dapr/Actors/UnitActor.cs
+++ b/src/Cvoya.Spring.Dapr/Actors/UnitActor.cs
@@ -1,10 +1,5 @@
-/*
- * Copyright CVOYA LLC.
- *
- * This source code is proprietary and confidential.
- * Unauthorized copying, modification, distribution, or use of this file,
- * via any medium, is strictly prohibited without the prior written consent of CVOYA LLC.
- */
+// Copyright CVOYA LLC. Licensed under the Business Source License 1.1.
+// See LICENSE.md in the project root for full license terms.
 
 namespace Cvoya.Spring.Dapr.Actors;
 

--- a/src/Cvoya.Spring.Dapr/Actors/UnitContext.cs
+++ b/src/Cvoya.Spring.Dapr/Actors/UnitContext.cs
@@ -1,10 +1,5 @@
-/*
- * Copyright CVOYA LLC.
- *
- * This source code is proprietary and confidential.
- * Unauthorized copying, modification, distribution, or use of this file,
- * via any medium, is strictly prohibited without the prior written consent of CVOYA LLC.
- */
+// Copyright CVOYA LLC. Licensed under the Business Source License 1.1.
+// See LICENSE.md in the project root for full license terms.
 
 namespace Cvoya.Spring.Dapr.Actors;
 

--- a/src/Cvoya.Spring.Dapr/Data/Configuration/ActivityEventRecordConfiguration.cs
+++ b/src/Cvoya.Spring.Dapr/Data/Configuration/ActivityEventRecordConfiguration.cs
@@ -1,10 +1,5 @@
-/*
- * Copyright CVOYA LLC.
- *
- * This source code is proprietary and confidential.
- * Unauthorized copying, modification, distribution, or use of this file,
- * via any medium, is strictly prohibited without the prior written consent of CVOYA LLC.
- */
+// Copyright CVOYA LLC. Licensed under the Business Source License 1.1.
+// See LICENSE.md in the project root for full license terms.
 
 namespace Cvoya.Spring.Dapr.Data.Configuration;
 

--- a/src/Cvoya.Spring.Dapr/Data/Configuration/AgentDefinitionEntityConfiguration.cs
+++ b/src/Cvoya.Spring.Dapr/Data/Configuration/AgentDefinitionEntityConfiguration.cs
@@ -1,10 +1,5 @@
-/*
- * Copyright CVOYA LLC.
- *
- * This source code is proprietary and confidential.
- * Unauthorized copying, modification, distribution, or use of this file,
- * via any medium, is strictly prohibited without the prior written consent of CVOYA LLC.
- */
+// Copyright CVOYA LLC. Licensed under the Business Source License 1.1.
+// See LICENSE.md in the project root for full license terms.
 
 namespace Cvoya.Spring.Dapr.Data.Configuration;
 

--- a/src/Cvoya.Spring.Dapr/Data/Configuration/ApiTokenEntityConfiguration.cs
+++ b/src/Cvoya.Spring.Dapr/Data/Configuration/ApiTokenEntityConfiguration.cs
@@ -1,10 +1,5 @@
-/*
- * Copyright CVOYA LLC.
- *
- * This source code is proprietary and confidential.
- * Unauthorized copying, modification, distribution, or use of this file,
- * via any medium, is strictly prohibited without the prior written consent of CVOYA LLC.
- */
+// Copyright CVOYA LLC. Licensed under the Business Source License 1.1.
+// See LICENSE.md in the project root for full license terms.
 
 namespace Cvoya.Spring.Dapr.Data.Configuration;
 

--- a/src/Cvoya.Spring.Dapr/Data/Configuration/ConnectorDefinitionEntityConfiguration.cs
+++ b/src/Cvoya.Spring.Dapr/Data/Configuration/ConnectorDefinitionEntityConfiguration.cs
@@ -1,10 +1,5 @@
-/*
- * Copyright CVOYA LLC.
- *
- * This source code is proprietary and confidential.
- * Unauthorized copying, modification, distribution, or use of this file,
- * via any medium, is strictly prohibited without the prior written consent of CVOYA LLC.
- */
+// Copyright CVOYA LLC. Licensed under the Business Source License 1.1.
+// See LICENSE.md in the project root for full license terms.
 
 namespace Cvoya.Spring.Dapr.Data.Configuration;
 

--- a/src/Cvoya.Spring.Dapr/Data/Configuration/TenantEntityConfiguration.cs
+++ b/src/Cvoya.Spring.Dapr/Data/Configuration/TenantEntityConfiguration.cs
@@ -1,10 +1,5 @@
-/*
- * Copyright CVOYA LLC.
- *
- * This source code is proprietary and confidential.
- * Unauthorized copying, modification, distribution, or use of this file,
- * via any medium, is strictly prohibited without the prior written consent of CVOYA LLC.
- */
+// Copyright CVOYA LLC. Licensed under the Business Source License 1.1.
+// See LICENSE.md in the project root for full license terms.
 
 namespace Cvoya.Spring.Dapr.Data.Configuration;
 

--- a/src/Cvoya.Spring.Dapr/Data/Configuration/UnitDefinitionEntityConfiguration.cs
+++ b/src/Cvoya.Spring.Dapr/Data/Configuration/UnitDefinitionEntityConfiguration.cs
@@ -1,10 +1,5 @@
-/*
- * Copyright CVOYA LLC.
- *
- * This source code is proprietary and confidential.
- * Unauthorized copying, modification, distribution, or use of this file,
- * via any medium, is strictly prohibited without the prior written consent of CVOYA LLC.
- */
+// Copyright CVOYA LLC. Licensed under the Business Source License 1.1.
+// See LICENSE.md in the project root for full license terms.
 
 namespace Cvoya.Spring.Dapr.Data.Configuration;
 

--- a/src/Cvoya.Spring.Dapr/Data/Configuration/UserEntityConfiguration.cs
+++ b/src/Cvoya.Spring.Dapr/Data/Configuration/UserEntityConfiguration.cs
@@ -1,10 +1,5 @@
-/*
- * Copyright CVOYA LLC.
- *
- * This source code is proprietary and confidential.
- * Unauthorized copying, modification, distribution, or use of this file,
- * via any medium, is strictly prohibited without the prior written consent of CVOYA LLC.
- */
+// Copyright CVOYA LLC. Licensed under the Business Source License 1.1.
+// See LICENSE.md in the project root for full license terms.
 
 namespace Cvoya.Spring.Dapr.Data.Configuration;
 

--- a/src/Cvoya.Spring.Dapr/Data/Entities/ActivityEventRecord.cs
+++ b/src/Cvoya.Spring.Dapr/Data/Entities/ActivityEventRecord.cs
@@ -1,10 +1,5 @@
-/*
- * Copyright CVOYA LLC.
- *
- * This source code is proprietary and confidential.
- * Unauthorized copying, modification, distribution, or use of this file,
- * via any medium, is strictly prohibited without the prior written consent of CVOYA LLC.
- */
+// Copyright CVOYA LLC. Licensed under the Business Source License 1.1.
+// See LICENSE.md in the project root for full license terms.
 
 namespace Cvoya.Spring.Dapr.Data.Entities;
 

--- a/src/Cvoya.Spring.Dapr/Data/Entities/AgentDefinitionEntity.cs
+++ b/src/Cvoya.Spring.Dapr/Data/Entities/AgentDefinitionEntity.cs
@@ -1,10 +1,5 @@
-/*
- * Copyright CVOYA LLC.
- *
- * This source code is proprietary and confidential.
- * Unauthorized copying, modification, distribution, or use of this file,
- * via any medium, is strictly prohibited without the prior written consent of CVOYA LLC.
- */
+// Copyright CVOYA LLC. Licensed under the Business Source License 1.1.
+// See LICENSE.md in the project root for full license terms.
 
 namespace Cvoya.Spring.Dapr.Data.Entities;
 

--- a/src/Cvoya.Spring.Dapr/Data/Entities/ApiTokenEntity.cs
+++ b/src/Cvoya.Spring.Dapr/Data/Entities/ApiTokenEntity.cs
@@ -1,10 +1,5 @@
-/*
- * Copyright CVOYA LLC.
- *
- * This source code is proprietary and confidential.
- * Unauthorized copying, modification, distribution, or use of this file,
- * via any medium, is strictly prohibited without the prior written consent of CVOYA LLC.
- */
+// Copyright CVOYA LLC. Licensed under the Business Source License 1.1.
+// See LICENSE.md in the project root for full license terms.
 
 namespace Cvoya.Spring.Dapr.Data.Entities;
 

--- a/src/Cvoya.Spring.Dapr/Data/Entities/ConnectorDefinitionEntity.cs
+++ b/src/Cvoya.Spring.Dapr/Data/Entities/ConnectorDefinitionEntity.cs
@@ -1,10 +1,5 @@
-/*
- * Copyright CVOYA LLC.
- *
- * This source code is proprietary and confidential.
- * Unauthorized copying, modification, distribution, or use of this file,
- * via any medium, is strictly prohibited without the prior written consent of CVOYA LLC.
- */
+// Copyright CVOYA LLC. Licensed under the Business Source License 1.1.
+// See LICENSE.md in the project root for full license terms.
 
 namespace Cvoya.Spring.Dapr.Data.Entities;
 

--- a/src/Cvoya.Spring.Dapr/Data/Entities/TenantEntity.cs
+++ b/src/Cvoya.Spring.Dapr/Data/Entities/TenantEntity.cs
@@ -1,10 +1,5 @@
-/*
- * Copyright CVOYA LLC.
- *
- * This source code is proprietary and confidential.
- * Unauthorized copying, modification, distribution, or use of this file,
- * via any medium, is strictly prohibited without the prior written consent of CVOYA LLC.
- */
+// Copyright CVOYA LLC. Licensed under the Business Source License 1.1.
+// See LICENSE.md in the project root for full license terms.
 
 namespace Cvoya.Spring.Dapr.Data.Entities;
 

--- a/src/Cvoya.Spring.Dapr/Data/Entities/UnitDefinitionEntity.cs
+++ b/src/Cvoya.Spring.Dapr/Data/Entities/UnitDefinitionEntity.cs
@@ -1,10 +1,5 @@
-/*
- * Copyright CVOYA LLC.
- *
- * This source code is proprietary and confidential.
- * Unauthorized copying, modification, distribution, or use of this file,
- * via any medium, is strictly prohibited without the prior written consent of CVOYA LLC.
- */
+// Copyright CVOYA LLC. Licensed under the Business Source License 1.1.
+// See LICENSE.md in the project root for full license terms.
 
 namespace Cvoya.Spring.Dapr.Data.Entities;
 

--- a/src/Cvoya.Spring.Dapr/Data/Entities/UserEntity.cs
+++ b/src/Cvoya.Spring.Dapr/Data/Entities/UserEntity.cs
@@ -1,10 +1,5 @@
-/*
- * Copyright CVOYA LLC.
- *
- * This source code is proprietary and confidential.
- * Unauthorized copying, modification, distribution, or use of this file,
- * via any medium, is strictly prohibited without the prior written consent of CVOYA LLC.
- */
+// Copyright CVOYA LLC. Licensed under the Business Source License 1.1.
+// See LICENSE.md in the project root for full license terms.
 
 namespace Cvoya.Spring.Dapr.Data.Entities;
 

--- a/src/Cvoya.Spring.Dapr/Data/IRepository.cs
+++ b/src/Cvoya.Spring.Dapr/Data/IRepository.cs
@@ -1,10 +1,5 @@
-/*
- * Copyright CVOYA LLC.
- *
- * This source code is proprietary and confidential.
- * Unauthorized copying, modification, distribution, or use of this file,
- * via any medium, is strictly prohibited without the prior written consent of CVOYA LLC.
- */
+// Copyright CVOYA LLC. Licensed under the Business Source License 1.1.
+// See LICENSE.md in the project root for full license terms.
 
 namespace Cvoya.Spring.Dapr.Data;
 

--- a/src/Cvoya.Spring.Dapr/Data/Repository.cs
+++ b/src/Cvoya.Spring.Dapr/Data/Repository.cs
@@ -1,10 +1,5 @@
-/*
- * Copyright CVOYA LLC.
- *
- * This source code is proprietary and confidential.
- * Unauthorized copying, modification, distribution, or use of this file,
- * via any medium, is strictly prohibited without the prior written consent of CVOYA LLC.
- */
+// Copyright CVOYA LLC. Licensed under the Business Source License 1.1.
+// See LICENSE.md in the project root for full license terms.
 
 namespace Cvoya.Spring.Dapr.Data;
 

--- a/src/Cvoya.Spring.Dapr/Data/SpringDbContext.cs
+++ b/src/Cvoya.Spring.Dapr/Data/SpringDbContext.cs
@@ -1,10 +1,5 @@
-/*
- * Copyright CVOYA LLC.
- *
- * This source code is proprietary and confidential.
- * Unauthorized copying, modification, distribution, or use of this file,
- * via any medium, is strictly prohibited without the prior written consent of CVOYA LLC.
- */
+// Copyright CVOYA LLC. Licensed under the Business Source License 1.1.
+// See LICENSE.md in the project root for full license terms.
 
 namespace Cvoya.Spring.Dapr.Data;
 

--- a/src/Cvoya.Spring.Dapr/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/Cvoya.Spring.Dapr/DependencyInjection/ServiceCollectionExtensions.cs
@@ -1,10 +1,5 @@
-/*
- * Copyright CVOYA LLC.
- *
- * This source code is proprietary and confidential.
- * Unauthorized copying, modification, distribution, or use of this file,
- * via any medium, is strictly prohibited without the prior written consent of CVOYA LLC.
- */
+// Copyright CVOYA LLC. Licensed under the Business Source License 1.1.
+// See LICENSE.md in the project root for full license terms.
 
 namespace Cvoya.Spring.Dapr.DependencyInjection;
 

--- a/src/Cvoya.Spring.Dapr/Execution/AiProviderOptions.cs
+++ b/src/Cvoya.Spring.Dapr/Execution/AiProviderOptions.cs
@@ -1,10 +1,5 @@
-/*
- * Copyright CVOYA LLC.
- *
- * This source code is proprietary and confidential.
- * Unauthorized copying, modification, distribution, or use of this file,
- * via any medium, is strictly prohibited without the prior written consent of CVOYA LLC.
- */
+// Copyright CVOYA LLC. Licensed under the Business Source License 1.1.
+// See LICENSE.md in the project root for full license terms.
 
 namespace Cvoya.Spring.Dapr.Execution;
 

--- a/src/Cvoya.Spring.Dapr/Execution/AnthropicProvider.cs
+++ b/src/Cvoya.Spring.Dapr/Execution/AnthropicProvider.cs
@@ -1,10 +1,5 @@
-/*
- * Copyright CVOYA LLC.
- *
- * This source code is proprietary and confidential.
- * Unauthorized copying, modification, distribution, or use of this file,
- * via any medium, is strictly prohibited without the prior written consent of CVOYA LLC.
- */
+// Copyright CVOYA LLC. Licensed under the Business Source License 1.1.
+// See LICENSE.md in the project root for full license terms.
 
 namespace Cvoya.Spring.Dapr.Execution;
 

--- a/src/Cvoya.Spring.Dapr/Execution/ContainerLifecycleManager.cs
+++ b/src/Cvoya.Spring.Dapr/Execution/ContainerLifecycleManager.cs
@@ -1,10 +1,5 @@
-/*
- * Copyright CVOYA LLC.
- *
- * This source code is proprietary and confidential.
- * Unauthorized copying, modification, distribution, or use of this file,
- * via any medium, is strictly prohibited without the prior written consent of CVOYA LLC.
- */
+// Copyright CVOYA LLC. Licensed under the Business Source License 1.1.
+// See LICENSE.md in the project root for full license terms.
 
 namespace Cvoya.Spring.Dapr.Execution;
 

--- a/src/Cvoya.Spring.Dapr/Execution/ContainerRuntimeOptions.cs
+++ b/src/Cvoya.Spring.Dapr/Execution/ContainerRuntimeOptions.cs
@@ -1,10 +1,5 @@
-/*
- * Copyright CVOYA LLC.
- *
- * This source code is proprietary and confidential.
- * Unauthorized copying, modification, distribution, or use of this file,
- * via any medium, is strictly prohibited without the prior written consent of CVOYA LLC.
- */
+// Copyright CVOYA LLC. Licensed under the Business Source License 1.1.
+// See LICENSE.md in the project root for full license terms.
 
 namespace Cvoya.Spring.Dapr.Execution;
 

--- a/src/Cvoya.Spring.Dapr/Execution/DaprSidecarManager.cs
+++ b/src/Cvoya.Spring.Dapr/Execution/DaprSidecarManager.cs
@@ -1,10 +1,5 @@
-/*
- * Copyright CVOYA LLC.
- *
- * This source code is proprietary and confidential.
- * Unauthorized copying, modification, distribution, or use of this file,
- * via any medium, is strictly prohibited without the prior written consent of CVOYA LLC.
- */
+// Copyright CVOYA LLC. Licensed under the Business Source License 1.1.
+// See LICENSE.md in the project root for full license terms.
 
 namespace Cvoya.Spring.Dapr.Execution;
 

--- a/src/Cvoya.Spring.Dapr/Execution/DelegatedExecutionDispatcher.cs
+++ b/src/Cvoya.Spring.Dapr/Execution/DelegatedExecutionDispatcher.cs
@@ -1,10 +1,5 @@
-/*
- * Copyright CVOYA LLC.
- *
- * This source code is proprietary and confidential.
- * Unauthorized copying, modification, distribution, or use of this file,
- * via any medium, is strictly prohibited without the prior written consent of CVOYA LLC.
- */
+// Copyright CVOYA LLC. Licensed under the Business Source License 1.1.
+// See LICENSE.md in the project root for full license terms.
 
 namespace Cvoya.Spring.Dapr.Execution;
 

--- a/src/Cvoya.Spring.Dapr/Execution/DockerRuntime.cs
+++ b/src/Cvoya.Spring.Dapr/Execution/DockerRuntime.cs
@@ -1,10 +1,5 @@
-/*
- * Copyright CVOYA LLC.
- *
- * This source code is proprietary and confidential.
- * Unauthorized copying, modification, distribution, or use of this file,
- * via any medium, is strictly prohibited without the prior written consent of CVOYA LLC.
- */
+// Copyright CVOYA LLC. Licensed under the Business Source License 1.1.
+// See LICENSE.md in the project root for full license terms.
 
 namespace Cvoya.Spring.Dapr.Execution;
 

--- a/src/Cvoya.Spring.Dapr/Execution/HostedExecutionDispatcher.cs
+++ b/src/Cvoya.Spring.Dapr/Execution/HostedExecutionDispatcher.cs
@@ -1,10 +1,5 @@
-/*
- * Copyright CVOYA LLC.
- *
- * This source code is proprietary and confidential.
- * Unauthorized copying, modification, distribution, or use of this file,
- * via any medium, is strictly prohibited without the prior written consent of CVOYA LLC.
- */
+// Copyright CVOYA LLC. Licensed under the Business Source License 1.1.
+// See LICENSE.md in the project root for full license terms.
 
 namespace Cvoya.Spring.Dapr.Execution;
 

--- a/src/Cvoya.Spring.Dapr/Execution/PodmanRuntime.cs
+++ b/src/Cvoya.Spring.Dapr/Execution/PodmanRuntime.cs
@@ -1,10 +1,5 @@
-/*
- * Copyright CVOYA LLC.
- *
- * This source code is proprietary and confidential.
- * Unauthorized copying, modification, distribution, or use of this file,
- * via any medium, is strictly prohibited without the prior written consent of CVOYA LLC.
- */
+// Copyright CVOYA LLC. Licensed under the Business Source License 1.1.
+// See LICENSE.md in the project root for full license terms.
 
 namespace Cvoya.Spring.Dapr.Execution;
 

--- a/src/Cvoya.Spring.Dapr/Execution/ProcessContainerRuntime.cs
+++ b/src/Cvoya.Spring.Dapr/Execution/ProcessContainerRuntime.cs
@@ -1,10 +1,5 @@
-/*
- * Copyright CVOYA LLC.
- *
- * This source code is proprietary and confidential.
- * Unauthorized copying, modification, distribution, or use of this file,
- * via any medium, is strictly prohibited without the prior written consent of CVOYA LLC.
- */
+// Copyright CVOYA LLC. Licensed under the Business Source License 1.1.
+// See LICENSE.md in the project root for full license terms.
 
 namespace Cvoya.Spring.Dapr.Execution;
 

--- a/src/Cvoya.Spring.Dapr/Execution/UsageStats.cs
+++ b/src/Cvoya.Spring.Dapr/Execution/UsageStats.cs
@@ -1,10 +1,5 @@
-/*
- * Copyright CVOYA LLC.
- *
- * This source code is proprietary and confidential.
- * Unauthorized copying, modification, distribution, or use of this file,
- * via any medium, is strictly prohibited without the prior written consent of CVOYA LLC.
- */
+// Copyright CVOYA LLC. Licensed under the Business Source License 1.1.
+// See LICENSE.md in the project root for full license terms.
 
 namespace Cvoya.Spring.Dapr.Execution;
 

--- a/src/Cvoya.Spring.Dapr/Orchestration/AiOrchestrationStrategy.cs
+++ b/src/Cvoya.Spring.Dapr/Orchestration/AiOrchestrationStrategy.cs
@@ -1,10 +1,5 @@
-/*
- * Copyright CVOYA LLC.
- *
- * This source code is proprietary and confidential.
- * Unauthorized copying, modification, distribution, or use of this file,
- * via any medium, is strictly prohibited without the prior written consent of CVOYA LLC.
- */
+// Copyright CVOYA LLC. Licensed under the Business Source License 1.1.
+// See LICENSE.md in the project root for full license terms.
 
 namespace Cvoya.Spring.Dapr.Orchestration;
 

--- a/src/Cvoya.Spring.Dapr/Orchestration/HybridOrchestrationStrategy.cs
+++ b/src/Cvoya.Spring.Dapr/Orchestration/HybridOrchestrationStrategy.cs
@@ -1,10 +1,5 @@
-/*
- * Copyright CVOYA LLC.
- *
- * This source code is proprietary and confidential.
- * Unauthorized copying, modification, distribution, or use of this file,
- * via any medium, is strictly prohibited without the prior written consent of CVOYA LLC.
- */
+// Copyright CVOYA LLC. Licensed under the Business Source License 1.1.
+// See LICENSE.md in the project root for full license terms.
 
 namespace Cvoya.Spring.Dapr.Orchestration;
 

--- a/src/Cvoya.Spring.Dapr/Orchestration/WorkflowOrchestrationOptions.cs
+++ b/src/Cvoya.Spring.Dapr/Orchestration/WorkflowOrchestrationOptions.cs
@@ -1,10 +1,5 @@
-/*
- * Copyright CVOYA LLC.
- *
- * This source code is proprietary and confidential.
- * Unauthorized copying, modification, distribution, or use of this file,
- * via any medium, is strictly prohibited without the prior written consent of CVOYA LLC.
- */
+// Copyright CVOYA LLC. Licensed under the Business Source License 1.1.
+// See LICENSE.md in the project root for full license terms.
 
 namespace Cvoya.Spring.Dapr.Orchestration;
 

--- a/src/Cvoya.Spring.Dapr/Orchestration/WorkflowOrchestrationStrategy.cs
+++ b/src/Cvoya.Spring.Dapr/Orchestration/WorkflowOrchestrationStrategy.cs
@@ -1,10 +1,5 @@
-/*
- * Copyright CVOYA LLC.
- *
- * This source code is proprietary and confidential.
- * Unauthorized copying, modification, distribution, or use of this file,
- * via any medium, is strictly prohibited without the prior written consent of CVOYA LLC.
- */
+// Copyright CVOYA LLC. Licensed under the Business Source License 1.1.
+// See LICENSE.md in the project root for full license terms.
 
 namespace Cvoya.Spring.Dapr.Orchestration;
 

--- a/src/Cvoya.Spring.Dapr/Prompts/ConversationContextBuilder.cs
+++ b/src/Cvoya.Spring.Dapr/Prompts/ConversationContextBuilder.cs
@@ -1,10 +1,5 @@
-/*
- * Copyright CVOYA LLC.
- *
- * This source code is proprietary and confidential.
- * Unauthorized copying, modification, distribution, or use of this file,
- * via any medium, is strictly prohibited without the prior written consent of CVOYA LLC.
- */
+// Copyright CVOYA LLC. Licensed under the Business Source License 1.1.
+// See LICENSE.md in the project root for full license terms.
 
 namespace Cvoya.Spring.Dapr.Prompts;
 

--- a/src/Cvoya.Spring.Dapr/Prompts/PlatformPromptProvider.cs
+++ b/src/Cvoya.Spring.Dapr/Prompts/PlatformPromptProvider.cs
@@ -1,10 +1,5 @@
-/*
- * Copyright CVOYA LLC.
- *
- * This source code is proprietary and confidential.
- * Unauthorized copying, modification, distribution, or use of this file,
- * via any medium, is strictly prohibited without the prior written consent of CVOYA LLC.
- */
+// Copyright CVOYA LLC. Licensed under the Business Source License 1.1.
+// See LICENSE.md in the project root for full license terms.
 
 namespace Cvoya.Spring.Dapr.Prompts;
 

--- a/src/Cvoya.Spring.Dapr/Prompts/PromptAssembler.cs
+++ b/src/Cvoya.Spring.Dapr/Prompts/PromptAssembler.cs
@@ -1,10 +1,5 @@
-/*
- * Copyright CVOYA LLC.
- *
- * This source code is proprietary and confidential.
- * Unauthorized copying, modification, distribution, or use of this file,
- * via any medium, is strictly prohibited without the prior written consent of CVOYA LLC.
- */
+// Copyright CVOYA LLC. Licensed under the Business Source License 1.1.
+// See LICENSE.md in the project root for full license terms.
 
 namespace Cvoya.Spring.Dapr.Prompts;
 

--- a/src/Cvoya.Spring.Dapr/Prompts/PromptAssemblyContext.cs
+++ b/src/Cvoya.Spring.Dapr/Prompts/PromptAssemblyContext.cs
@@ -1,10 +1,5 @@
-/*
- * Copyright CVOYA LLC.
- *
- * This source code is proprietary and confidential.
- * Unauthorized copying, modification, distribution, or use of this file,
- * via any medium, is strictly prohibited without the prior written consent of CVOYA LLC.
- */
+// Copyright CVOYA LLC. Licensed under the Business Source License 1.1.
+// See LICENSE.md in the project root for full license terms.
 
 namespace Cvoya.Spring.Dapr.Prompts;
 

--- a/src/Cvoya.Spring.Dapr/Prompts/UnitContextBuilder.cs
+++ b/src/Cvoya.Spring.Dapr/Prompts/UnitContextBuilder.cs
@@ -1,10 +1,5 @@
-/*
- * Copyright CVOYA LLC.
- *
- * This source code is proprietary and confidential.
- * Unauthorized copying, modification, distribution, or use of this file,
- * via any medium, is strictly prohibited without the prior written consent of CVOYA LLC.
- */
+// Copyright CVOYA LLC. Licensed under the Business Source License 1.1.
+// See LICENSE.md in the project root for full license terms.
 
 namespace Cvoya.Spring.Dapr.Prompts;
 

--- a/src/Cvoya.Spring.Dapr/Routing/DirectoryCache.cs
+++ b/src/Cvoya.Spring.Dapr/Routing/DirectoryCache.cs
@@ -1,10 +1,5 @@
-/*
- * Copyright CVOYA LLC.
- *
- * This source code is proprietary and confidential.
- * Unauthorized copying, modification, distribution, or use of this file,
- * via any medium, is strictly prohibited without the prior written consent of CVOYA LLC.
- */
+// Copyright CVOYA LLC. Licensed under the Business Source License 1.1.
+// See LICENSE.md in the project root for full license terms.
 
 namespace Cvoya.Spring.Dapr.Routing;
 

--- a/src/Cvoya.Spring.Dapr/Routing/DirectoryService.cs
+++ b/src/Cvoya.Spring.Dapr/Routing/DirectoryService.cs
@@ -1,10 +1,5 @@
-/*
- * Copyright CVOYA LLC.
- *
- * This source code is proprietary and confidential.
- * Unauthorized copying, modification, distribution, or use of this file,
- * via any medium, is strictly prohibited without the prior written consent of CVOYA LLC.
- */
+// Copyright CVOYA LLC. Licensed under the Business Source License 1.1.
+// See LICENSE.md in the project root for full license terms.
 
 namespace Cvoya.Spring.Dapr.Routing;
 

--- a/src/Cvoya.Spring.Dapr/Routing/MessageRouter.cs
+++ b/src/Cvoya.Spring.Dapr/Routing/MessageRouter.cs
@@ -1,10 +1,5 @@
-/*
- * Copyright CVOYA LLC.
- *
- * This source code is proprietary and confidential.
- * Unauthorized copying, modification, distribution, or use of this file,
- * via any medium, is strictly prohibited without the prior written consent of CVOYA LLC.
- */
+// Copyright CVOYA LLC. Licensed under the Business Source License 1.1.
+// See LICENSE.md in the project root for full license terms.
 
 namespace Cvoya.Spring.Dapr.Routing;
 

--- a/src/Cvoya.Spring.Dapr/Routing/RoutingError.cs
+++ b/src/Cvoya.Spring.Dapr/Routing/RoutingError.cs
@@ -1,10 +1,5 @@
-/*
- * Copyright CVOYA LLC.
- *
- * This source code is proprietary and confidential.
- * Unauthorized copying, modification, distribution, or use of this file,
- * via any medium, is strictly prohibited without the prior written consent of CVOYA LLC.
- */
+// Copyright CVOYA LLC. Licensed under the Business Source License 1.1.
+// See LICENSE.md in the project root for full license terms.
 
 namespace Cvoya.Spring.Dapr.Routing;
 

--- a/src/Cvoya.Spring.Dapr/State/ActorStateStoreAdapter.cs
+++ b/src/Cvoya.Spring.Dapr/State/ActorStateStoreAdapter.cs
@@ -1,10 +1,5 @@
-/*
- * Copyright CVOYA LLC.
- *
- * This source code is proprietary and confidential.
- * Unauthorized copying, modification, distribution, or use of this file,
- * via any medium, is strictly prohibited without the prior written consent of CVOYA LLC.
- */
+// Copyright CVOYA LLC. Licensed under the Business Source License 1.1.
+// See LICENSE.md in the project root for full license terms.
 
 namespace Cvoya.Spring.Dapr.State;
 

--- a/src/Cvoya.Spring.Dapr/State/DaprStateStore.cs
+++ b/src/Cvoya.Spring.Dapr/State/DaprStateStore.cs
@@ -1,10 +1,5 @@
-/*
- * Copyright CVOYA LLC.
- *
- * This source code is proprietary and confidential.
- * Unauthorized copying, modification, distribution, or use of this file,
- * via any medium, is strictly prohibited without the prior written consent of CVOYA LLC.
- */
+// Copyright CVOYA LLC. Licensed under the Business Source License 1.1.
+// See LICENSE.md in the project root for full license terms.
 
 namespace Cvoya.Spring.Dapr.State;
 

--- a/src/Cvoya.Spring.Dapr/State/DaprStateStoreOptions.cs
+++ b/src/Cvoya.Spring.Dapr/State/DaprStateStoreOptions.cs
@@ -1,10 +1,5 @@
-/*
- * Copyright CVOYA LLC.
- *
- * This source code is proprietary and confidential.
- * Unauthorized copying, modification, distribution, or use of this file,
- * via any medium, is strictly prohibited without the prior written consent of CVOYA LLC.
- */
+// Copyright CVOYA LLC. Licensed under the Business Source License 1.1.
+// See LICENSE.md in the project root for full license terms.
 
 namespace Cvoya.Spring.Dapr.State;
 

--- a/src/Cvoya.Spring.Dapr/Tools/CheckMessagesTool.cs
+++ b/src/Cvoya.Spring.Dapr/Tools/CheckMessagesTool.cs
@@ -1,10 +1,5 @@
-/*
- * Copyright CVOYA LLC.
- *
- * This source code is proprietary and confidential.
- * Unauthorized copying, modification, distribution, or use of this file,
- * via any medium, is strictly prohibited without the prior written consent of CVOYA LLC.
- */
+// Copyright CVOYA LLC. Licensed under the Business Source License 1.1.
+// See LICENSE.md in the project root for full license terms.
 
 namespace Cvoya.Spring.Dapr.Tools;
 

--- a/src/Cvoya.Spring.Dapr/Tools/CheckpointTool.cs
+++ b/src/Cvoya.Spring.Dapr/Tools/CheckpointTool.cs
@@ -1,10 +1,5 @@
-/*
- * Copyright CVOYA LLC.
- *
- * This source code is proprietary and confidential.
- * Unauthorized copying, modification, distribution, or use of this file,
- * via any medium, is strictly prohibited without the prior written consent of CVOYA LLC.
- */
+// Copyright CVOYA LLC. Licensed under the Business Source License 1.1.
+// See LICENSE.md in the project root for full license terms.
 
 namespace Cvoya.Spring.Dapr.Tools;
 

--- a/src/Cvoya.Spring.Dapr/Tools/DiscoverPeersTool.cs
+++ b/src/Cvoya.Spring.Dapr/Tools/DiscoverPeersTool.cs
@@ -1,10 +1,5 @@
-/*
- * Copyright CVOYA LLC.
- *
- * This source code is proprietary and confidential.
- * Unauthorized copying, modification, distribution, or use of this file,
- * via any medium, is strictly prohibited without the prior written consent of CVOYA LLC.
- */
+// Copyright CVOYA LLC. Licensed under the Business Source License 1.1.
+// See LICENSE.md in the project root for full license terms.
 
 namespace Cvoya.Spring.Dapr.Tools;
 

--- a/src/Cvoya.Spring.Dapr/Tools/EscalateTool.cs
+++ b/src/Cvoya.Spring.Dapr/Tools/EscalateTool.cs
@@ -1,10 +1,5 @@
-/*
- * Copyright CVOYA LLC.
- *
- * This source code is proprietary and confidential.
- * Unauthorized copying, modification, distribution, or use of this file,
- * via any medium, is strictly prohibited without the prior written consent of CVOYA LLC.
- */
+// Copyright CVOYA LLC. Licensed under the Business Source License 1.1.
+// See LICENSE.md in the project root for full license terms.
 
 namespace Cvoya.Spring.Dapr.Tools;
 

--- a/src/Cvoya.Spring.Dapr/Tools/PlatformToolRegistry.cs
+++ b/src/Cvoya.Spring.Dapr/Tools/PlatformToolRegistry.cs
@@ -1,10 +1,5 @@
-/*
- * Copyright CVOYA LLC.
- *
- * This source code is proprietary and confidential.
- * Unauthorized copying, modification, distribution, or use of this file,
- * via any medium, is strictly prohibited without the prior written consent of CVOYA LLC.
- */
+// Copyright CVOYA LLC. Licensed under the Business Source License 1.1.
+// See LICENSE.md in the project root for full license terms.
 
 namespace Cvoya.Spring.Dapr.Tools;
 

--- a/src/Cvoya.Spring.Dapr/Tools/ReportStatusTool.cs
+++ b/src/Cvoya.Spring.Dapr/Tools/ReportStatusTool.cs
@@ -1,10 +1,5 @@
-/*
- * Copyright CVOYA LLC.
- *
- * This source code is proprietary and confidential.
- * Unauthorized copying, modification, distribution, or use of this file,
- * via any medium, is strictly prohibited without the prior written consent of CVOYA LLC.
- */
+// Copyright CVOYA LLC. Licensed under the Business Source License 1.1.
+// See LICENSE.md in the project root for full license terms.
 
 namespace Cvoya.Spring.Dapr.Tools;
 

--- a/src/Cvoya.Spring.Dapr/Tools/RequestHelpTool.cs
+++ b/src/Cvoya.Spring.Dapr/Tools/RequestHelpTool.cs
@@ -1,10 +1,5 @@
-/*
- * Copyright CVOYA LLC.
- *
- * This source code is proprietary and confidential.
- * Unauthorized copying, modification, distribution, or use of this file,
- * via any medium, is strictly prohibited without the prior written consent of CVOYA LLC.
- */
+// Copyright CVOYA LLC. Licensed under the Business Source License 1.1.
+// See LICENSE.md in the project root for full license terms.
 
 namespace Cvoya.Spring.Dapr.Tools;
 

--- a/src/Cvoya.Spring.Dapr/Tools/ToolDispatcher.cs
+++ b/src/Cvoya.Spring.Dapr/Tools/ToolDispatcher.cs
@@ -1,10 +1,5 @@
-/*
- * Copyright CVOYA LLC.
- *
- * This source code is proprietary and confidential.
- * Unauthorized copying, modification, distribution, or use of this file,
- * via any medium, is strictly prohibited without the prior written consent of CVOYA LLC.
- */
+// Copyright CVOYA LLC. Licensed under the Business Source License 1.1.
+// See LICENSE.md in the project root for full license terms.
 
 namespace Cvoya.Spring.Dapr.Tools;
 

--- a/src/Cvoya.Spring.Dapr/Tools/ToolExecutionContext.cs
+++ b/src/Cvoya.Spring.Dapr/Tools/ToolExecutionContext.cs
@@ -1,10 +1,5 @@
-/*
- * Copyright CVOYA LLC.
- *
- * This source code is proprietary and confidential.
- * Unauthorized copying, modification, distribution, or use of this file,
- * via any medium, is strictly prohibited without the prior written consent of CVOYA LLC.
- */
+// Copyright CVOYA LLC. Licensed under the Business Source License 1.1.
+// See LICENSE.md in the project root for full license terms.
 
 namespace Cvoya.Spring.Dapr.Tools;
 

--- a/src/Cvoya.Spring.Dapr/Workflows/Activities/RegisterAgentActivity.cs
+++ b/src/Cvoya.Spring.Dapr/Workflows/Activities/RegisterAgentActivity.cs
@@ -1,10 +1,5 @@
-/*
- * Copyright CVOYA LLC.
- *
- * This source code is proprietary and confidential.
- * Unauthorized copying, modification, distribution, or use of this file,
- * via any medium, is strictly prohibited without the prior written consent of CVOYA LLC.
- */
+// Copyright CVOYA LLC. Licensed under the Business Source License 1.1.
+// See LICENSE.md in the project root for full license terms.
 
 namespace Cvoya.Spring.Dapr.Workflows.Activities;
 

--- a/src/Cvoya.Spring.Dapr/Workflows/Activities/UnregisterAgentActivity.cs
+++ b/src/Cvoya.Spring.Dapr/Workflows/Activities/UnregisterAgentActivity.cs
@@ -1,10 +1,5 @@
-/*
- * Copyright CVOYA LLC.
- *
- * This source code is proprietary and confidential.
- * Unauthorized copying, modification, distribution, or use of this file,
- * via any medium, is strictly prohibited without the prior written consent of CVOYA LLC.
- */
+// Copyright CVOYA LLC. Licensed under the Business Source License 1.1.
+// See LICENSE.md in the project root for full license terms.
 
 namespace Cvoya.Spring.Dapr.Workflows.Activities;
 

--- a/src/Cvoya.Spring.Dapr/Workflows/Activities/ValidateAgentDefinitionActivity.cs
+++ b/src/Cvoya.Spring.Dapr/Workflows/Activities/ValidateAgentDefinitionActivity.cs
@@ -1,10 +1,5 @@
-/*
- * Copyright CVOYA LLC.
- *
- * This source code is proprietary and confidential.
- * Unauthorized copying, modification, distribution, or use of this file,
- * via any medium, is strictly prohibited without the prior written consent of CVOYA LLC.
- */
+// Copyright CVOYA LLC. Licensed under the Business Source License 1.1.
+// See LICENSE.md in the project root for full license terms.
 
 namespace Cvoya.Spring.Dapr.Workflows.Activities;
 

--- a/src/Cvoya.Spring.Dapr/Workflows/AgentLifecycleInput.cs
+++ b/src/Cvoya.Spring.Dapr/Workflows/AgentLifecycleInput.cs
@@ -1,10 +1,5 @@
-/*
- * Copyright CVOYA LLC.
- *
- * This source code is proprietary and confidential.
- * Unauthorized copying, modification, distribution, or use of this file,
- * via any medium, is strictly prohibited without the prior written consent of CVOYA LLC.
- */
+// Copyright CVOYA LLC. Licensed under the Business Source License 1.1.
+// See LICENSE.md in the project root for full license terms.
 
 namespace Cvoya.Spring.Dapr.Workflows;
 

--- a/src/Cvoya.Spring.Dapr/Workflows/AgentLifecycleOutput.cs
+++ b/src/Cvoya.Spring.Dapr/Workflows/AgentLifecycleOutput.cs
@@ -1,10 +1,5 @@
-/*
- * Copyright CVOYA LLC.
- *
- * This source code is proprietary and confidential.
- * Unauthorized copying, modification, distribution, or use of this file,
- * via any medium, is strictly prohibited without the prior written consent of CVOYA LLC.
- */
+// Copyright CVOYA LLC. Licensed under the Business Source License 1.1.
+// See LICENSE.md in the project root for full license terms.
 
 namespace Cvoya.Spring.Dapr.Workflows;
 

--- a/src/Cvoya.Spring.Dapr/Workflows/AgentLifecycleWorkflow.cs
+++ b/src/Cvoya.Spring.Dapr/Workflows/AgentLifecycleWorkflow.cs
@@ -1,10 +1,5 @@
-/*
- * Copyright CVOYA LLC.
- *
- * This source code is proprietary and confidential.
- * Unauthorized copying, modification, distribution, or use of this file,
- * via any medium, is strictly prohibited without the prior written consent of CVOYA LLC.
- */
+// Copyright CVOYA LLC. Licensed under the Business Source License 1.1.
+// See LICENSE.md in the project root for full license terms.
 
 namespace Cvoya.Spring.Dapr.Workflows;
 

--- a/src/Cvoya.Spring.Dapr/Workflows/CloningInput.cs
+++ b/src/Cvoya.Spring.Dapr/Workflows/CloningInput.cs
@@ -1,10 +1,5 @@
-/*
- * Copyright CVOYA LLC.
- *
- * This source code is proprietary and confidential.
- * Unauthorized copying, modification, distribution, or use of this file,
- * via any medium, is strictly prohibited without the prior written consent of CVOYA LLC.
- */
+// Copyright CVOYA LLC. Licensed under the Business Source License 1.1.
+// See LICENSE.md in the project root for full license terms.
 
 namespace Cvoya.Spring.Dapr.Workflows;
 

--- a/src/Cvoya.Spring.Dapr/Workflows/CloningLifecycleWorkflow.cs
+++ b/src/Cvoya.Spring.Dapr/Workflows/CloningLifecycleWorkflow.cs
@@ -1,10 +1,5 @@
-/*
- * Copyright CVOYA LLC.
- *
- * This source code is proprietary and confidential.
- * Unauthorized copying, modification, distribution, or use of this file,
- * via any medium, is strictly prohibited without the prior written consent of CVOYA LLC.
- */
+// Copyright CVOYA LLC. Licensed under the Business Source License 1.1.
+// See LICENSE.md in the project root for full license terms.
 
 namespace Cvoya.Spring.Dapr.Workflows;
 

--- a/src/Cvoya.Spring.Dapr/Workflows/CloningOutput.cs
+++ b/src/Cvoya.Spring.Dapr/Workflows/CloningOutput.cs
@@ -1,10 +1,5 @@
-/*
- * Copyright CVOYA LLC.
- *
- * This source code is proprietary and confidential.
- * Unauthorized copying, modification, distribution, or use of this file,
- * via any medium, is strictly prohibited without the prior written consent of CVOYA LLC.
- */
+// Copyright CVOYA LLC. Licensed under the Business Source License 1.1.
+// See LICENSE.md in the project root for full license terms.
 
 namespace Cvoya.Spring.Dapr.Workflows;
 

--- a/src/Cvoya.Spring.Dapr/Workflows/LifecycleOperation.cs
+++ b/src/Cvoya.Spring.Dapr/Workflows/LifecycleOperation.cs
@@ -1,10 +1,5 @@
-/*
- * Copyright CVOYA LLC.
- *
- * This source code is proprietary and confidential.
- * Unauthorized copying, modification, distribution, or use of this file,
- * via any medium, is strictly prohibited without the prior written consent of CVOYA LLC.
- */
+// Copyright CVOYA LLC. Licensed under the Business Source License 1.1.
+// See LICENSE.md in the project root for full license terms.
 
 namespace Cvoya.Spring.Dapr.Workflows;
 

--- a/src/Cvoya.Spring.Host.Api/Auth/ApiTokenAuthHandler.cs
+++ b/src/Cvoya.Spring.Host.Api/Auth/ApiTokenAuthHandler.cs
@@ -1,10 +1,5 @@
-/*
- * Copyright CVOYA LLC.
- *
- * This source code is proprietary and confidential.
- * Unauthorized copying, modification, distribution, or use of this file,
- * via any medium, is strictly prohibited without the prior written consent of CVOYA LLC.
- */
+// Copyright CVOYA LLC. Licensed under the Business Source License 1.1.
+// See LICENSE.md in the project root for full license terms.
 
 namespace Cvoya.Spring.Host.Api.Auth;
 

--- a/src/Cvoya.Spring.Host.Api/Auth/AuthConstants.cs
+++ b/src/Cvoya.Spring.Host.Api/Auth/AuthConstants.cs
@@ -1,10 +1,5 @@
-/*
- * Copyright CVOYA LLC.
- *
- * This source code is proprietary and confidential.
- * Unauthorized copying, modification, distribution, or use of this file,
- * via any medium, is strictly prohibited without the prior written consent of CVOYA LLC.
- */
+// Copyright CVOYA LLC. Licensed under the Business Source License 1.1.
+// See LICENSE.md in the project root for full license terms.
 
 namespace Cvoya.Spring.Host.Api.Auth;
 

--- a/src/Cvoya.Spring.Host.Api/Auth/LocalDevAuthHandler.cs
+++ b/src/Cvoya.Spring.Host.Api/Auth/LocalDevAuthHandler.cs
@@ -1,10 +1,5 @@
-/*
- * Copyright CVOYA LLC.
- *
- * This source code is proprietary and confidential.
- * Unauthorized copying, modification, distribution, or use of this file,
- * via any medium, is strictly prohibited without the prior written consent of CVOYA LLC.
- */
+// Copyright CVOYA LLC. Licensed under the Business Source License 1.1.
+// See LICENSE.md in the project root for full license terms.
 
 namespace Cvoya.Spring.Host.Api.Auth;
 

--- a/src/Cvoya.Spring.Host.Api/Auth/OAuthAuthHandler.cs
+++ b/src/Cvoya.Spring.Host.Api/Auth/OAuthAuthHandler.cs
@@ -1,10 +1,5 @@
-/*
- * Copyright CVOYA LLC.
- *
- * This source code is proprietary and confidential.
- * Unauthorized copying, modification, distribution, or use of this file,
- * via any medium, is strictly prohibited without the prior written consent of CVOYA LLC.
- */
+// Copyright CVOYA LLC. Licensed under the Business Source License 1.1.
+// See LICENSE.md in the project root for full license terms.
 
 namespace Cvoya.Spring.Host.Api.Auth;
 

--- a/src/Cvoya.Spring.Host.Api/Auth/OAuthOptions.cs
+++ b/src/Cvoya.Spring.Host.Api/Auth/OAuthOptions.cs
@@ -1,10 +1,5 @@
-/*
- * Copyright CVOYA LLC.
- *
- * This source code is proprietary and confidential.
- * Unauthorized copying, modification, distribution, or use of this file,
- * via any medium, is strictly prohibited without the prior written consent of CVOYA LLC.
- */
+// Copyright CVOYA LLC. Licensed under the Business Source License 1.1.
+// See LICENSE.md in the project root for full license terms.
 
 namespace Cvoya.Spring.Host.Api.Auth;
 

--- a/src/Cvoya.Spring.Host.Api/Endpoints/AgentEndpoints.cs
+++ b/src/Cvoya.Spring.Host.Api/Endpoints/AgentEndpoints.cs
@@ -1,10 +1,5 @@
-/*
- * Copyright CVOYA LLC.
- *
- * This source code is proprietary and confidential.
- * Unauthorized copying, modification, distribution, or use of this file,
- * via any medium, is strictly prohibited without the prior written consent of CVOYA LLC.
- */
+// Copyright CVOYA LLC. Licensed under the Business Source License 1.1.
+// See LICENSE.md in the project root for full license terms.
 
 namespace Cvoya.Spring.Host.Api.Endpoints;
 

--- a/src/Cvoya.Spring.Host.Api/Endpoints/AuthEndpoints.cs
+++ b/src/Cvoya.Spring.Host.Api/Endpoints/AuthEndpoints.cs
@@ -1,10 +1,5 @@
-/*
- * Copyright CVOYA LLC.
- *
- * This source code is proprietary and confidential.
- * Unauthorized copying, modification, distribution, or use of this file,
- * via any medium, is strictly prohibited without the prior written consent of CVOYA LLC.
- */
+// Copyright CVOYA LLC. Licensed under the Business Source License 1.1.
+// See LICENSE.md in the project root for full license terms.
 
 namespace Cvoya.Spring.Host.Api.Endpoints;
 

--- a/src/Cvoya.Spring.Host.Api/Endpoints/DirectoryEndpoints.cs
+++ b/src/Cvoya.Spring.Host.Api/Endpoints/DirectoryEndpoints.cs
@@ -1,10 +1,5 @@
-/*
- * Copyright CVOYA LLC.
- *
- * This source code is proprietary and confidential.
- * Unauthorized copying, modification, distribution, or use of this file,
- * via any medium, is strictly prohibited without the prior written consent of CVOYA LLC.
- */
+// Copyright CVOYA LLC. Licensed under the Business Source License 1.1.
+// See LICENSE.md in the project root for full license terms.
 
 namespace Cvoya.Spring.Host.Api.Endpoints;
 

--- a/src/Cvoya.Spring.Host.Api/Endpoints/MessageEndpoints.cs
+++ b/src/Cvoya.Spring.Host.Api/Endpoints/MessageEndpoints.cs
@@ -1,10 +1,5 @@
-/*
- * Copyright CVOYA LLC.
- *
- * This source code is proprietary and confidential.
- * Unauthorized copying, modification, distribution, or use of this file,
- * via any medium, is strictly prohibited without the prior written consent of CVOYA LLC.
- */
+// Copyright CVOYA LLC. Licensed under the Business Source License 1.1.
+// See LICENSE.md in the project root for full license terms.
 
 namespace Cvoya.Spring.Host.Api.Endpoints;
 

--- a/src/Cvoya.Spring.Host.Api/Endpoints/UnitEndpoints.cs
+++ b/src/Cvoya.Spring.Host.Api/Endpoints/UnitEndpoints.cs
@@ -1,10 +1,5 @@
-/*
- * Copyright CVOYA LLC.
- *
- * This source code is proprietary and confidential.
- * Unauthorized copying, modification, distribution, or use of this file,
- * via any medium, is strictly prohibited without the prior written consent of CVOYA LLC.
- */
+// Copyright CVOYA LLC. Licensed under the Business Source License 1.1.
+// See LICENSE.md in the project root for full license terms.
 
 namespace Cvoya.Spring.Host.Api.Endpoints;
 

--- a/src/Cvoya.Spring.Host.Api/Models/AgentModels.cs
+++ b/src/Cvoya.Spring.Host.Api/Models/AgentModels.cs
@@ -1,10 +1,5 @@
-/*
- * Copyright CVOYA LLC.
- *
- * This source code is proprietary and confidential.
- * Unauthorized copying, modification, distribution, or use of this file,
- * via any medium, is strictly prohibited without the prior written consent of CVOYA LLC.
- */
+// Copyright CVOYA LLC. Licensed under the Business Source License 1.1.
+// See LICENSE.md in the project root for full license terms.
 
 namespace Cvoya.Spring.Host.Api.Models;
 

--- a/src/Cvoya.Spring.Host.Api/Models/AuthModels.cs
+++ b/src/Cvoya.Spring.Host.Api/Models/AuthModels.cs
@@ -1,10 +1,5 @@
-/*
- * Copyright CVOYA LLC.
- *
- * This source code is proprietary and confidential.
- * Unauthorized copying, modification, distribution, or use of this file,
- * via any medium, is strictly prohibited without the prior written consent of CVOYA LLC.
- */
+// Copyright CVOYA LLC. Licensed under the Business Source License 1.1.
+// See LICENSE.md in the project root for full license terms.
 
 namespace Cvoya.Spring.Host.Api.Models;
 

--- a/src/Cvoya.Spring.Host.Api/Models/DirectoryModels.cs
+++ b/src/Cvoya.Spring.Host.Api/Models/DirectoryModels.cs
@@ -1,10 +1,5 @@
-/*
- * Copyright CVOYA LLC.
- *
- * This source code is proprietary and confidential.
- * Unauthorized copying, modification, distribution, or use of this file,
- * via any medium, is strictly prohibited without the prior written consent of CVOYA LLC.
- */
+// Copyright CVOYA LLC. Licensed under the Business Source License 1.1.
+// See LICENSE.md in the project root for full license terms.
 
 namespace Cvoya.Spring.Host.Api.Models;
 

--- a/src/Cvoya.Spring.Host.Api/Models/MessageModels.cs
+++ b/src/Cvoya.Spring.Host.Api/Models/MessageModels.cs
@@ -1,10 +1,5 @@
-/*
- * Copyright CVOYA LLC.
- *
- * This source code is proprietary and confidential.
- * Unauthorized copying, modification, distribution, or use of this file,
- * via any medium, is strictly prohibited without the prior written consent of CVOYA LLC.
- */
+// Copyright CVOYA LLC. Licensed under the Business Source License 1.1.
+// See LICENSE.md in the project root for full license terms.
 
 namespace Cvoya.Spring.Host.Api.Models;
 

--- a/src/Cvoya.Spring.Host.Api/Models/UnitModels.cs
+++ b/src/Cvoya.Spring.Host.Api/Models/UnitModels.cs
@@ -1,10 +1,5 @@
-/*
- * Copyright CVOYA LLC.
- *
- * This source code is proprietary and confidential.
- * Unauthorized copying, modification, distribution, or use of this file,
- * via any medium, is strictly prohibited without the prior written consent of CVOYA LLC.
- */
+// Copyright CVOYA LLC. Licensed under the Business Source License 1.1.
+// See LICENSE.md in the project root for full license terms.
 
 namespace Cvoya.Spring.Host.Api.Models;
 

--- a/src/Cvoya.Spring.Host.Api/Program.cs
+++ b/src/Cvoya.Spring.Host.Api/Program.cs
@@ -1,10 +1,5 @@
-/*
- * Copyright CVOYA LLC.
- *
- * This source code is proprietary and confidential.
- * Unauthorized copying, modification, distribution, or use of this file,
- * via any medium, is strictly prohibited without the prior written consent of CVOYA LLC.
- */
+// Copyright CVOYA LLC. Licensed under the Business Source License 1.1.
+// See LICENSE.md in the project root for full license terms.
 
 using Cvoya.Spring.Dapr.DependencyInjection;
 using Cvoya.Spring.Host.Api.Auth;

--- a/src/Cvoya.Spring.Host.Worker/Program.cs
+++ b/src/Cvoya.Spring.Host.Worker/Program.cs
@@ -1,10 +1,5 @@
-/*
- * Copyright CVOYA LLC.
- *
- * This source code is proprietary and confidential.
- * Unauthorized copying, modification, distribution, or use of this file,
- * via any medium, is strictly prohibited without the prior written consent of CVOYA LLC.
- */
+// Copyright CVOYA LLC. Licensed under the Business Source License 1.1.
+// See LICENSE.md in the project root for full license terms.
 
 using System.Runtime.InteropServices;
 using Cvoya.Spring.Dapr.Actors;

--- a/src/Cvoya.Spring.Web/Program.cs
+++ b/src/Cvoya.Spring.Web/Program.cs
@@ -1,10 +1,5 @@
-/*
- * Copyright CVOYA LLC.
- *
- * This source code is proprietary and confidential.
- * Unauthorized copying, modification, distribution, or use of this file,
- * via any medium, is strictly prohibited without the prior written consent of CVOYA LLC.
- */
+// Copyright CVOYA LLC. Licensed under the Business Source License 1.1.
+// See LICENSE.md in the project root for full license terms.
 
 var builder = WebApplication.CreateBuilder(args);
 

--- a/tests/Cvoya.Spring.Cli.Tests/AddressParserTests.cs
+++ b/tests/Cvoya.Spring.Cli.Tests/AddressParserTests.cs
@@ -1,10 +1,5 @@
-/*
- * Copyright CVOYA LLC.
- *
- * This source code is proprietary and confidential.
- * Unauthorized copying, modification, distribution, or use of this file,
- * via any medium, is strictly prohibited without the prior written consent of CVOYA LLC.
- */
+// Copyright CVOYA LLC. Licensed under the Business Source License 1.1.
+// See LICENSE.md in the project root for full license terms.
 
 namespace Cvoya.Spring.Cli.Tests;
 

--- a/tests/Cvoya.Spring.Cli.Tests/CliConfigTests.cs
+++ b/tests/Cvoya.Spring.Cli.Tests/CliConfigTests.cs
@@ -1,10 +1,5 @@
-/*
- * Copyright CVOYA LLC.
- *
- * This source code is proprietary and confidential.
- * Unauthorized copying, modification, distribution, or use of this file,
- * via any medium, is strictly prohibited without the prior written consent of CVOYA LLC.
- */
+// Copyright CVOYA LLC. Licensed under the Business Source License 1.1.
+// See LICENSE.md in the project root for full license terms.
 
 namespace Cvoya.Spring.Cli.Tests;
 

--- a/tests/Cvoya.Spring.Cli.Tests/CliTests.cs
+++ b/tests/Cvoya.Spring.Cli.Tests/CliTests.cs
@@ -1,10 +1,5 @@
-/*
- * Copyright CVOYA LLC.
- *
- * This source code is proprietary and confidential.
- * Unauthorized copying, modification, distribution, or use of this file,
- * via any medium, is strictly prohibited without the prior written consent of CVOYA LLC.
- */
+// Copyright CVOYA LLC. Licensed under the Business Source License 1.1.
+// See LICENSE.md in the project root for full license terms.
 
 namespace Cvoya.Spring.Cli.Tests;
 

--- a/tests/Cvoya.Spring.Cli.Tests/CommandParsingTests.cs
+++ b/tests/Cvoya.Spring.Cli.Tests/CommandParsingTests.cs
@@ -1,10 +1,5 @@
-/*
- * Copyright CVOYA LLC.
- *
- * This source code is proprietary and confidential.
- * Unauthorized copying, modification, distribution, or use of this file,
- * via any medium, is strictly prohibited without the prior written consent of CVOYA LLC.
- */
+// Copyright CVOYA LLC. Licensed under the Business Source License 1.1.
+// See LICENSE.md in the project root for full license terms.
 
 namespace Cvoya.Spring.Cli.Tests;
 

--- a/tests/Cvoya.Spring.Cli.Tests/OutputFormatterTests.cs
+++ b/tests/Cvoya.Spring.Cli.Tests/OutputFormatterTests.cs
@@ -1,10 +1,5 @@
-/*
- * Copyright CVOYA LLC.
- *
- * This source code is proprietary and confidential.
- * Unauthorized copying, modification, distribution, or use of this file,
- * via any medium, is strictly prohibited without the prior written consent of CVOYA LLC.
- */
+// Copyright CVOYA LLC. Licensed under the Business Source License 1.1.
+// See LICENSE.md in the project root for full license terms.
 
 namespace Cvoya.Spring.Cli.Tests;
 

--- a/tests/Cvoya.Spring.Cli.Tests/SpringApiClientTests.cs
+++ b/tests/Cvoya.Spring.Cli.Tests/SpringApiClientTests.cs
@@ -1,10 +1,5 @@
-/*
- * Copyright CVOYA LLC.
- *
- * This source code is proprietary and confidential.
- * Unauthorized copying, modification, distribution, or use of this file,
- * via any medium, is strictly prohibited without the prior written consent of CVOYA LLC.
- */
+// Copyright CVOYA LLC. Licensed under the Business Source License 1.1.
+// See LICENSE.md in the project root for full license terms.
 
 namespace Cvoya.Spring.Cli.Tests;
 

--- a/tests/Cvoya.Spring.Connector.GitHub.Tests/CreatePullRequestSkillTests.cs
+++ b/tests/Cvoya.Spring.Connector.GitHub.Tests/CreatePullRequestSkillTests.cs
@@ -1,10 +1,5 @@
-/*
- * Copyright CVOYA LLC.
- *
- * This source code is proprietary and confidential.
- * Unauthorized copying, modification, distribution, or use of this file,
- * via any medium, is strictly prohibited without the prior written consent of CVOYA LLC.
- */
+// Copyright CVOYA LLC. Licensed under the Business Source License 1.1.
+// See LICENSE.md in the project root for full license terms.
 
 namespace Cvoya.Spring.Connector.GitHub.Tests;
 

--- a/tests/Cvoya.Spring.Connector.GitHub.Tests/GitHubSkillRegistryTests.cs
+++ b/tests/Cvoya.Spring.Connector.GitHub.Tests/GitHubSkillRegistryTests.cs
@@ -1,10 +1,5 @@
-/*
- * Copyright CVOYA LLC.
- *
- * This source code is proprietary and confidential.
- * Unauthorized copying, modification, distribution, or use of this file,
- * via any medium, is strictly prohibited without the prior written consent of CVOYA LLC.
- */
+// Copyright CVOYA LLC. Licensed under the Business Source License 1.1.
+// See LICENSE.md in the project root for full license terms.
 
 namespace Cvoya.Spring.Connector.GitHub.Tests;
 

--- a/tests/Cvoya.Spring.Connector.GitHub.Tests/GitHubWebhookHandlerTests.cs
+++ b/tests/Cvoya.Spring.Connector.GitHub.Tests/GitHubWebhookHandlerTests.cs
@@ -1,10 +1,5 @@
-/*
- * Copyright CVOYA LLC.
- *
- * This source code is proprietary and confidential.
- * Unauthorized copying, modification, distribution, or use of this file,
- * via any medium, is strictly prohibited without the prior written consent of CVOYA LLC.
- */
+// Copyright CVOYA LLC. Licensed under the Business Source License 1.1.
+// See LICENSE.md in the project root for full license terms.
 
 namespace Cvoya.Spring.Connector.GitHub.Tests;
 

--- a/tests/Cvoya.Spring.Connector.GitHub.Tests/ReadFileSkillTests.cs
+++ b/tests/Cvoya.Spring.Connector.GitHub.Tests/ReadFileSkillTests.cs
@@ -1,10 +1,5 @@
-/*
- * Copyright CVOYA LLC.
- *
- * This source code is proprietary and confidential.
- * Unauthorized copying, modification, distribution, or use of this file,
- * via any medium, is strictly prohibited without the prior written consent of CVOYA LLC.
- */
+// Copyright CVOYA LLC. Licensed under the Business Source License 1.1.
+// See LICENSE.md in the project root for full license terms.
 
 namespace Cvoya.Spring.Connector.GitHub.Tests;
 

--- a/tests/Cvoya.Spring.Connector.GitHub.Tests/WebhookSignatureValidatorTests.cs
+++ b/tests/Cvoya.Spring.Connector.GitHub.Tests/WebhookSignatureValidatorTests.cs
@@ -1,10 +1,5 @@
-/*
- * Copyright CVOYA LLC.
- *
- * This source code is proprietary and confidential.
- * Unauthorized copying, modification, distribution, or use of this file,
- * via any medium, is strictly prohibited without the prior written consent of CVOYA LLC.
- */
+// Copyright CVOYA LLC. Licensed under the Business Source License 1.1.
+// See LICENSE.md in the project root for full license terms.
 
 namespace Cvoya.Spring.Connector.GitHub.Tests;
 

--- a/tests/Cvoya.Spring.Core.Tests/AgentTests.cs
+++ b/tests/Cvoya.Spring.Core.Tests/AgentTests.cs
@@ -1,10 +1,5 @@
-/*
- * Copyright CVOYA LLC.
- *
- * This source code is proprietary and confidential.
- * Unauthorized copying, modification, distribution, or use of this file,
- * via any medium, is strictly prohibited without the prior written consent of CVOYA LLC.
- */
+// Copyright CVOYA LLC. Licensed under the Business Source License 1.1.
+// See LICENSE.md in the project root for full license terms.
 
 namespace Cvoya.Spring.Core.Tests;
 

--- a/tests/Cvoya.Spring.Core.Tests/CoreDomainTests.cs
+++ b/tests/Cvoya.Spring.Core.Tests/CoreDomainTests.cs
@@ -1,10 +1,5 @@
-/*
- * Copyright CVOYA LLC.
- *
- * This source code is proprietary and confidential.
- * Unauthorized copying, modification, distribution, or use of this file,
- * via any medium, is strictly prohibited without the prior written consent of CVOYA LLC.
- */
+// Copyright CVOYA LLC. Licensed under the Business Source License 1.1.
+// See LICENSE.md in the project root for full license terms.
 
 namespace Cvoya.Spring.Core.Tests;
 

--- a/tests/Cvoya.Spring.Dapr.Tests/Actors/AgentActorTests.cs
+++ b/tests/Cvoya.Spring.Dapr.Tests/Actors/AgentActorTests.cs
@@ -1,10 +1,5 @@
-/*
- * Copyright CVOYA LLC.
- *
- * This source code is proprietary and confidential.
- * Unauthorized copying, modification, distribution, or use of this file,
- * via any medium, is strictly prohibited without the prior written consent of CVOYA LLC.
- */
+// Copyright CVOYA LLC. Licensed under the Business Source License 1.1.
+// See LICENSE.md in the project root for full license terms.
 
 namespace Cvoya.Spring.Dapr.Tests.Actors;
 

--- a/tests/Cvoya.Spring.Dapr.Tests/Actors/ConnectorActorTests.cs
+++ b/tests/Cvoya.Spring.Dapr.Tests/Actors/ConnectorActorTests.cs
@@ -1,10 +1,5 @@
-/*
- * Copyright CVOYA LLC.
- *
- * This source code is proprietary and confidential.
- * Unauthorized copying, modification, distribution, or use of this file,
- * via any medium, is strictly prohibited without the prior written consent of CVOYA LLC.
- */
+// Copyright CVOYA LLC. Licensed under the Business Source License 1.1.
+// See LICENSE.md in the project root for full license terms.
 
 namespace Cvoya.Spring.Dapr.Tests.Actors;
 

--- a/tests/Cvoya.Spring.Dapr.Tests/Actors/HumanActorTests.cs
+++ b/tests/Cvoya.Spring.Dapr.Tests/Actors/HumanActorTests.cs
@@ -1,10 +1,5 @@
-/*
- * Copyright CVOYA LLC.
- *
- * This source code is proprietary and confidential.
- * Unauthorized copying, modification, distribution, or use of this file,
- * via any medium, is strictly prohibited without the prior written consent of CVOYA LLC.
- */
+// Copyright CVOYA LLC. Licensed under the Business Source License 1.1.
+// See LICENSE.md in the project root for full license terms.
 
 namespace Cvoya.Spring.Dapr.Tests.Actors;
 

--- a/tests/Cvoya.Spring.Dapr.Tests/Actors/UnitActorTests.cs
+++ b/tests/Cvoya.Spring.Dapr.Tests/Actors/UnitActorTests.cs
@@ -1,10 +1,5 @@
-/*
- * Copyright CVOYA LLC.
- *
- * This source code is proprietary and confidential.
- * Unauthorized copying, modification, distribution, or use of this file,
- * via any medium, is strictly prohibited without the prior written consent of CVOYA LLC.
- */
+// Copyright CVOYA LLC. Licensed under the Business Source License 1.1.
+// See LICENSE.md in the project root for full license terms.
 
 namespace Cvoya.Spring.Dapr.Tests.Actors;
 

--- a/tests/Cvoya.Spring.Dapr.Tests/Data/RepositoryTests.cs
+++ b/tests/Cvoya.Spring.Dapr.Tests/Data/RepositoryTests.cs
@@ -1,10 +1,5 @@
-/*
- * Copyright CVOYA LLC.
- *
- * This source code is proprietary and confidential.
- * Unauthorized copying, modification, distribution, or use of this file,
- * via any medium, is strictly prohibited without the prior written consent of CVOYA LLC.
- */
+// Copyright CVOYA LLC. Licensed under the Business Source License 1.1.
+// See LICENSE.md in the project root for full license terms.
 
 namespace Cvoya.Spring.Dapr.Tests.Data;
 

--- a/tests/Cvoya.Spring.Dapr.Tests/Data/SpringDbContextTests.cs
+++ b/tests/Cvoya.Spring.Dapr.Tests/Data/SpringDbContextTests.cs
@@ -1,10 +1,5 @@
-/*
- * Copyright CVOYA LLC.
- *
- * This source code is proprietary and confidential.
- * Unauthorized copying, modification, distribution, or use of this file,
- * via any medium, is strictly prohibited without the prior written consent of CVOYA LLC.
- */
+// Copyright CVOYA LLC. Licensed under the Business Source License 1.1.
+// See LICENSE.md in the project root for full license terms.
 
 namespace Cvoya.Spring.Dapr.Tests.Data;
 

--- a/tests/Cvoya.Spring.Dapr.Tests/DependencyInjection/ServiceCollectionExtensionsTests.cs
+++ b/tests/Cvoya.Spring.Dapr.Tests/DependencyInjection/ServiceCollectionExtensionsTests.cs
@@ -1,10 +1,5 @@
-/*
- * Copyright CVOYA LLC.
- *
- * This source code is proprietary and confidential.
- * Unauthorized copying, modification, distribution, or use of this file,
- * via any medium, is strictly prohibited without the prior written consent of CVOYA LLC.
- */
+// Copyright CVOYA LLC. Licensed under the Business Source License 1.1.
+// See LICENSE.md in the project root for full license terms.
 
 namespace Cvoya.Spring.Dapr.Tests.DependencyInjection;
 

--- a/tests/Cvoya.Spring.Dapr.Tests/Execution/AnthropicProviderTests.cs
+++ b/tests/Cvoya.Spring.Dapr.Tests/Execution/AnthropicProviderTests.cs
@@ -1,10 +1,5 @@
-/*
- * Copyright CVOYA LLC.
- *
- * This source code is proprietary and confidential.
- * Unauthorized copying, modification, distribution, or use of this file,
- * via any medium, is strictly prohibited without the prior written consent of CVOYA LLC.
- */
+// Copyright CVOYA LLC. Licensed under the Business Source License 1.1.
+// See LICENSE.md in the project root for full license terms.
 
 namespace Cvoya.Spring.Dapr.Tests.Execution;
 

--- a/tests/Cvoya.Spring.Dapr.Tests/Execution/ContainerLifecycleManagerTests.cs
+++ b/tests/Cvoya.Spring.Dapr.Tests/Execution/ContainerLifecycleManagerTests.cs
@@ -1,10 +1,5 @@
-/*
- * Copyright CVOYA LLC.
- *
- * This source code is proprietary and confidential.
- * Unauthorized copying, modification, distribution, or use of this file,
- * via any medium, is strictly prohibited without the prior written consent of CVOYA LLC.
- */
+// Copyright CVOYA LLC. Licensed under the Business Source License 1.1.
+// See LICENSE.md in the project root for full license terms.
 
 namespace Cvoya.Spring.Dapr.Tests.Execution;
 

--- a/tests/Cvoya.Spring.Dapr.Tests/Execution/DaprSidecarManagerTests.cs
+++ b/tests/Cvoya.Spring.Dapr.Tests/Execution/DaprSidecarManagerTests.cs
@@ -1,10 +1,5 @@
-/*
- * Copyright CVOYA LLC.
- *
- * This source code is proprietary and confidential.
- * Unauthorized copying, modification, distribution, or use of this file,
- * via any medium, is strictly prohibited without the prior written consent of CVOYA LLC.
- */
+// Copyright CVOYA LLC. Licensed under the Business Source License 1.1.
+// See LICENSE.md in the project root for full license terms.
 
 namespace Cvoya.Spring.Dapr.Tests.Execution;
 

--- a/tests/Cvoya.Spring.Dapr.Tests/Execution/DelegatedExecutionDispatcherTests.cs
+++ b/tests/Cvoya.Spring.Dapr.Tests/Execution/DelegatedExecutionDispatcherTests.cs
@@ -1,10 +1,5 @@
-/*
- * Copyright CVOYA LLC.
- *
- * This source code is proprietary and confidential.
- * Unauthorized copying, modification, distribution, or use of this file,
- * via any medium, is strictly prohibited without the prior written consent of CVOYA LLC.
- */
+// Copyright CVOYA LLC. Licensed under the Business Source License 1.1.
+// See LICENSE.md in the project root for full license terms.
 
 namespace Cvoya.Spring.Dapr.Tests.Execution;
 

--- a/tests/Cvoya.Spring.Dapr.Tests/Execution/HostedExecutionDispatcherTests.cs
+++ b/tests/Cvoya.Spring.Dapr.Tests/Execution/HostedExecutionDispatcherTests.cs
@@ -1,10 +1,5 @@
-/*
- * Copyright CVOYA LLC.
- *
- * This source code is proprietary and confidential.
- * Unauthorized copying, modification, distribution, or use of this file,
- * via any medium, is strictly prohibited without the prior written consent of CVOYA LLC.
- */
+// Copyright CVOYA LLC. Licensed under the Business Source License 1.1.
+// See LICENSE.md in the project root for full license terms.
 
 namespace Cvoya.Spring.Dapr.Tests.Execution;
 

--- a/tests/Cvoya.Spring.Dapr.Tests/Execution/ProcessContainerRuntimeTests.cs
+++ b/tests/Cvoya.Spring.Dapr.Tests/Execution/ProcessContainerRuntimeTests.cs
@@ -1,10 +1,5 @@
-/*
- * Copyright CVOYA LLC.
- *
- * This source code is proprietary and confidential.
- * Unauthorized copying, modification, distribution, or use of this file,
- * via any medium, is strictly prohibited without the prior written consent of CVOYA LLC.
- */
+// Copyright CVOYA LLC. Licensed under the Business Source License 1.1.
+// See LICENSE.md in the project root for full license terms.
 
 namespace Cvoya.Spring.Dapr.Tests.Execution;
 

--- a/tests/Cvoya.Spring.Dapr.Tests/Orchestration/AiOrchestrationStrategyTests.cs
+++ b/tests/Cvoya.Spring.Dapr.Tests/Orchestration/AiOrchestrationStrategyTests.cs
@@ -1,10 +1,5 @@
-/*
- * Copyright CVOYA LLC.
- *
- * This source code is proprietary and confidential.
- * Unauthorized copying, modification, distribution, or use of this file,
- * via any medium, is strictly prohibited without the prior written consent of CVOYA LLC.
- */
+// Copyright CVOYA LLC. Licensed under the Business Source License 1.1.
+// See LICENSE.md in the project root for full license terms.
 
 namespace Cvoya.Spring.Dapr.Tests.Orchestration;
 

--- a/tests/Cvoya.Spring.Dapr.Tests/Orchestration/HybridOrchestrationStrategyTests.cs
+++ b/tests/Cvoya.Spring.Dapr.Tests/Orchestration/HybridOrchestrationStrategyTests.cs
@@ -1,10 +1,5 @@
-/*
- * Copyright CVOYA LLC.
- *
- * This source code is proprietary and confidential.
- * Unauthorized copying, modification, distribution, or use of this file,
- * via any medium, is strictly prohibited without the prior written consent of CVOYA LLC.
- */
+// Copyright CVOYA LLC. Licensed under the Business Source License 1.1.
+// See LICENSE.md in the project root for full license terms.
 
 namespace Cvoya.Spring.Dapr.Tests.Orchestration;
 

--- a/tests/Cvoya.Spring.Dapr.Tests/Orchestration/WorkflowOrchestrationStrategyTests.cs
+++ b/tests/Cvoya.Spring.Dapr.Tests/Orchestration/WorkflowOrchestrationStrategyTests.cs
@@ -1,10 +1,5 @@
-/*
- * Copyright CVOYA LLC.
- *
- * This source code is proprietary and confidential.
- * Unauthorized copying, modification, distribution, or use of this file,
- * via any medium, is strictly prohibited without the prior written consent of CVOYA LLC.
- */
+// Copyright CVOYA LLC. Licensed under the Business Source License 1.1.
+// See LICENSE.md in the project root for full license terms.
 
 namespace Cvoya.Spring.Dapr.Tests.Orchestration;
 

--- a/tests/Cvoya.Spring.Dapr.Tests/Prompts/ConversationContextBuilderTests.cs
+++ b/tests/Cvoya.Spring.Dapr.Tests/Prompts/ConversationContextBuilderTests.cs
@@ -1,10 +1,5 @@
-/*
- * Copyright CVOYA LLC.
- *
- * This source code is proprietary and confidential.
- * Unauthorized copying, modification, distribution, or use of this file,
- * via any medium, is strictly prohibited without the prior written consent of CVOYA LLC.
- */
+// Copyright CVOYA LLC. Licensed under the Business Source License 1.1.
+// See LICENSE.md in the project root for full license terms.
 
 namespace Cvoya.Spring.Dapr.Tests.Prompts;
 

--- a/tests/Cvoya.Spring.Dapr.Tests/Prompts/PlatformPromptProviderTests.cs
+++ b/tests/Cvoya.Spring.Dapr.Tests/Prompts/PlatformPromptProviderTests.cs
@@ -1,10 +1,5 @@
-/*
- * Copyright CVOYA LLC.
- *
- * This source code is proprietary and confidential.
- * Unauthorized copying, modification, distribution, or use of this file,
- * via any medium, is strictly prohibited without the prior written consent of CVOYA LLC.
- */
+// Copyright CVOYA LLC. Licensed under the Business Source License 1.1.
+// See LICENSE.md in the project root for full license terms.
 
 namespace Cvoya.Spring.Dapr.Tests.Prompts;
 

--- a/tests/Cvoya.Spring.Dapr.Tests/Prompts/PromptAssemblerTests.cs
+++ b/tests/Cvoya.Spring.Dapr.Tests/Prompts/PromptAssemblerTests.cs
@@ -1,10 +1,5 @@
-/*
- * Copyright CVOYA LLC.
- *
- * This source code is proprietary and confidential.
- * Unauthorized copying, modification, distribution, or use of this file,
- * via any medium, is strictly prohibited without the prior written consent of CVOYA LLC.
- */
+// Copyright CVOYA LLC. Licensed under the Business Source License 1.1.
+// See LICENSE.md in the project root for full license terms.
 
 namespace Cvoya.Spring.Dapr.Tests.Prompts;
 

--- a/tests/Cvoya.Spring.Dapr.Tests/Prompts/UnitContextBuilderTests.cs
+++ b/tests/Cvoya.Spring.Dapr.Tests/Prompts/UnitContextBuilderTests.cs
@@ -1,10 +1,5 @@
-/*
- * Copyright CVOYA LLC.
- *
- * This source code is proprietary and confidential.
- * Unauthorized copying, modification, distribution, or use of this file,
- * via any medium, is strictly prohibited without the prior written consent of CVOYA LLC.
- */
+// Copyright CVOYA LLC. Licensed under the Business Source License 1.1.
+// See LICENSE.md in the project root for full license terms.
 
 namespace Cvoya.Spring.Dapr.Tests.Prompts;
 

--- a/tests/Cvoya.Spring.Dapr.Tests/Routing/DirectoryCacheTests.cs
+++ b/tests/Cvoya.Spring.Dapr.Tests/Routing/DirectoryCacheTests.cs
@@ -1,10 +1,5 @@
-/*
- * Copyright CVOYA LLC.
- *
- * This source code is proprietary and confidential.
- * Unauthorized copying, modification, distribution, or use of this file,
- * via any medium, is strictly prohibited without the prior written consent of CVOYA LLC.
- */
+// Copyright CVOYA LLC. Licensed under the Business Source License 1.1.
+// See LICENSE.md in the project root for full license terms.
 
 namespace Cvoya.Spring.Dapr.Tests.Routing;
 

--- a/tests/Cvoya.Spring.Dapr.Tests/Routing/DirectoryServiceTests.cs
+++ b/tests/Cvoya.Spring.Dapr.Tests/Routing/DirectoryServiceTests.cs
@@ -1,10 +1,5 @@
-/*
- * Copyright CVOYA LLC.
- *
- * This source code is proprietary and confidential.
- * Unauthorized copying, modification, distribution, or use of this file,
- * via any medium, is strictly prohibited without the prior written consent of CVOYA LLC.
- */
+// Copyright CVOYA LLC. Licensed under the Business Source License 1.1.
+// See LICENSE.md in the project root for full license terms.
 
 namespace Cvoya.Spring.Dapr.Tests.Routing;
 

--- a/tests/Cvoya.Spring.Dapr.Tests/Routing/MessageRouterTests.cs
+++ b/tests/Cvoya.Spring.Dapr.Tests/Routing/MessageRouterTests.cs
@@ -1,10 +1,5 @@
-/*
- * Copyright CVOYA LLC.
- *
- * This source code is proprietary and confidential.
- * Unauthorized copying, modification, distribution, or use of this file,
- * via any medium, is strictly prohibited without the prior written consent of CVOYA LLC.
- */
+// Copyright CVOYA LLC. Licensed under the Business Source License 1.1.
+// See LICENSE.md in the project root for full license terms.
 
 namespace Cvoya.Spring.Dapr.Tests.Routing;
 

--- a/tests/Cvoya.Spring.Dapr.Tests/State/ActorStateStoreAdapterTests.cs
+++ b/tests/Cvoya.Spring.Dapr.Tests/State/ActorStateStoreAdapterTests.cs
@@ -1,10 +1,5 @@
-/*
- * Copyright CVOYA LLC.
- *
- * This source code is proprietary and confidential.
- * Unauthorized copying, modification, distribution, or use of this file,
- * via any medium, is strictly prohibited without the prior written consent of CVOYA LLC.
- */
+// Copyright CVOYA LLC. Licensed under the Business Source License 1.1.
+// See LICENSE.md in the project root for full license terms.
 
 namespace Cvoya.Spring.Dapr.Tests.State;
 

--- a/tests/Cvoya.Spring.Dapr.Tests/State/DaprStateStoreTests.cs
+++ b/tests/Cvoya.Spring.Dapr.Tests/State/DaprStateStoreTests.cs
@@ -1,10 +1,5 @@
-/*
- * Copyright CVOYA LLC.
- *
- * This source code is proprietary and confidential.
- * Unauthorized copying, modification, distribution, or use of this file,
- * via any medium, is strictly prohibited without the prior written consent of CVOYA LLC.
- */
+// Copyright CVOYA LLC. Licensed under the Business Source License 1.1.
+// See LICENSE.md in the project root for full license terms.
 
 namespace Cvoya.Spring.Dapr.Tests.State;
 

--- a/tests/Cvoya.Spring.Dapr.Tests/State/StateSerializationTests.cs
+++ b/tests/Cvoya.Spring.Dapr.Tests/State/StateSerializationTests.cs
@@ -1,10 +1,5 @@
-/*
- * Copyright CVOYA LLC.
- *
- * This source code is proprietary and confidential.
- * Unauthorized copying, modification, distribution, or use of this file,
- * via any medium, is strictly prohibited without the prior written consent of CVOYA LLC.
- */
+// Copyright CVOYA LLC. Licensed under the Business Source License 1.1.
+// See LICENSE.md in the project root for full license terms.
 
 namespace Cvoya.Spring.Dapr.Tests.State;
 

--- a/tests/Cvoya.Spring.Dapr.Tests/Tools/CheckMessagesToolTests.cs
+++ b/tests/Cvoya.Spring.Dapr.Tests/Tools/CheckMessagesToolTests.cs
@@ -1,10 +1,5 @@
-/*
- * Copyright CVOYA LLC.
- *
- * This source code is proprietary and confidential.
- * Unauthorized copying, modification, distribution, or use of this file,
- * via any medium, is strictly prohibited without the prior written consent of CVOYA LLC.
- */
+// Copyright CVOYA LLC. Licensed under the Business Source License 1.1.
+// See LICENSE.md in the project root for full license terms.
 
 namespace Cvoya.Spring.Dapr.Tests.Tools;
 

--- a/tests/Cvoya.Spring.Dapr.Tests/Tools/CheckpointToolTests.cs
+++ b/tests/Cvoya.Spring.Dapr.Tests/Tools/CheckpointToolTests.cs
@@ -1,10 +1,5 @@
-/*
- * Copyright CVOYA LLC.
- *
- * This source code is proprietary and confidential.
- * Unauthorized copying, modification, distribution, or use of this file,
- * via any medium, is strictly prohibited without the prior written consent of CVOYA LLC.
- */
+// Copyright CVOYA LLC. Licensed under the Business Source License 1.1.
+// See LICENSE.md in the project root for full license terms.
 
 namespace Cvoya.Spring.Dapr.Tests.Tools;
 

--- a/tests/Cvoya.Spring.Dapr.Tests/Tools/DiscoverPeersToolTests.cs
+++ b/tests/Cvoya.Spring.Dapr.Tests/Tools/DiscoverPeersToolTests.cs
@@ -1,10 +1,5 @@
-/*
- * Copyright CVOYA LLC.
- *
- * This source code is proprietary and confidential.
- * Unauthorized copying, modification, distribution, or use of this file,
- * via any medium, is strictly prohibited without the prior written consent of CVOYA LLC.
- */
+// Copyright CVOYA LLC. Licensed under the Business Source License 1.1.
+// See LICENSE.md in the project root for full license terms.
 
 namespace Cvoya.Spring.Dapr.Tests.Tools;
 

--- a/tests/Cvoya.Spring.Dapr.Tests/Tools/PlatformToolRegistryTests.cs
+++ b/tests/Cvoya.Spring.Dapr.Tests/Tools/PlatformToolRegistryTests.cs
@@ -1,10 +1,5 @@
-/*
- * Copyright CVOYA LLC.
- *
- * This source code is proprietary and confidential.
- * Unauthorized copying, modification, distribution, or use of this file,
- * via any medium, is strictly prohibited without the prior written consent of CVOYA LLC.
- */
+// Copyright CVOYA LLC. Licensed under the Business Source License 1.1.
+// See LICENSE.md in the project root for full license terms.
 
 namespace Cvoya.Spring.Dapr.Tests.Tools;
 

--- a/tests/Cvoya.Spring.Dapr.Tests/Tools/RequestHelpToolTests.cs
+++ b/tests/Cvoya.Spring.Dapr.Tests/Tools/RequestHelpToolTests.cs
@@ -1,10 +1,5 @@
-/*
- * Copyright CVOYA LLC.
- *
- * This source code is proprietary and confidential.
- * Unauthorized copying, modification, distribution, or use of this file,
- * via any medium, is strictly prohibited without the prior written consent of CVOYA LLC.
- */
+// Copyright CVOYA LLC. Licensed under the Business Source License 1.1.
+// See LICENSE.md in the project root for full license terms.
 
 namespace Cvoya.Spring.Dapr.Tests.Tools;
 

--- a/tests/Cvoya.Spring.Dapr.Tests/Tools/ToolDispatcherTests.cs
+++ b/tests/Cvoya.Spring.Dapr.Tests/Tools/ToolDispatcherTests.cs
@@ -1,10 +1,5 @@
-/*
- * Copyright CVOYA LLC.
- *
- * This source code is proprietary and confidential.
- * Unauthorized copying, modification, distribution, or use of this file,
- * via any medium, is strictly prohibited without the prior written consent of CVOYA LLC.
- */
+// Copyright CVOYA LLC. Licensed under the Business Source License 1.1.
+// See LICENSE.md in the project root for full license terms.
 
 namespace Cvoya.Spring.Dapr.Tests.Tools;
 

--- a/tests/Cvoya.Spring.Dapr.Tests/Workflows/AgentLifecycleWorkflowTests.cs
+++ b/tests/Cvoya.Spring.Dapr.Tests/Workflows/AgentLifecycleWorkflowTests.cs
@@ -1,10 +1,5 @@
-/*
- * Copyright CVOYA LLC.
- *
- * This source code is proprietary and confidential.
- * Unauthorized copying, modification, distribution, or use of this file,
- * via any medium, is strictly prohibited without the prior written consent of CVOYA LLC.
- */
+// Copyright CVOYA LLC. Licensed under the Business Source License 1.1.
+// See LICENSE.md in the project root for full license terms.
 
 namespace Cvoya.Spring.Dapr.Tests.Workflows;
 

--- a/tests/Cvoya.Spring.Dapr.Tests/Workflows/CloningLifecycleWorkflowTests.cs
+++ b/tests/Cvoya.Spring.Dapr.Tests/Workflows/CloningLifecycleWorkflowTests.cs
@@ -1,10 +1,5 @@
-/*
- * Copyright CVOYA LLC.
- *
- * This source code is proprietary and confidential.
- * Unauthorized copying, modification, distribution, or use of this file,
- * via any medium, is strictly prohibited without the prior written consent of CVOYA LLC.
- */
+// Copyright CVOYA LLC. Licensed under the Business Source License 1.1.
+// See LICENSE.md in the project root for full license terms.
 
 namespace Cvoya.Spring.Dapr.Tests.Workflows;
 

--- a/tests/Cvoya.Spring.Dapr.Tests/Workflows/RegisterAgentActivityTests.cs
+++ b/tests/Cvoya.Spring.Dapr.Tests/Workflows/RegisterAgentActivityTests.cs
@@ -1,10 +1,5 @@
-/*
- * Copyright CVOYA LLC.
- *
- * This source code is proprietary and confidential.
- * Unauthorized copying, modification, distribution, or use of this file,
- * via any medium, is strictly prohibited without the prior written consent of CVOYA LLC.
- */
+// Copyright CVOYA LLC. Licensed under the Business Source License 1.1.
+// See LICENSE.md in the project root for full license terms.
 
 namespace Cvoya.Spring.Dapr.Tests.Workflows;
 

--- a/tests/Cvoya.Spring.Dapr.Tests/Workflows/UnregisterAgentActivityTests.cs
+++ b/tests/Cvoya.Spring.Dapr.Tests/Workflows/UnregisterAgentActivityTests.cs
@@ -1,10 +1,5 @@
-/*
- * Copyright CVOYA LLC.
- *
- * This source code is proprietary and confidential.
- * Unauthorized copying, modification, distribution, or use of this file,
- * via any medium, is strictly prohibited without the prior written consent of CVOYA LLC.
- */
+// Copyright CVOYA LLC. Licensed under the Business Source License 1.1.
+// See LICENSE.md in the project root for full license terms.
 
 namespace Cvoya.Spring.Dapr.Tests.Workflows;
 

--- a/tests/Cvoya.Spring.Dapr.Tests/Workflows/ValidateAgentDefinitionActivityTests.cs
+++ b/tests/Cvoya.Spring.Dapr.Tests/Workflows/ValidateAgentDefinitionActivityTests.cs
@@ -1,10 +1,5 @@
-/*
- * Copyright CVOYA LLC.
- *
- * This source code is proprietary and confidential.
- * Unauthorized copying, modification, distribution, or use of this file,
- * via any medium, is strictly prohibited without the prior written consent of CVOYA LLC.
- */
+// Copyright CVOYA LLC. Licensed under the Business Source License 1.1.
+// See LICENSE.md in the project root for full license terms.
 
 namespace Cvoya.Spring.Dapr.Tests.Workflows;
 

--- a/tests/Cvoya.Spring.Host.Api.Tests/AgentEndpointsTests.cs
+++ b/tests/Cvoya.Spring.Host.Api.Tests/AgentEndpointsTests.cs
@@ -1,10 +1,5 @@
-/*
- * Copyright CVOYA LLC.
- *
- * This source code is proprietary and confidential.
- * Unauthorized copying, modification, distribution, or use of this file,
- * via any medium, is strictly prohibited without the prior written consent of CVOYA LLC.
- */
+// Copyright CVOYA LLC. Licensed under the Business Source License 1.1.
+// See LICENSE.md in the project root for full license terms.
 
 namespace Cvoya.Spring.Host.Api.Tests;
 

--- a/tests/Cvoya.Spring.Host.Api.Tests/Auth/ApiTokenAuthHandlerTests.cs
+++ b/tests/Cvoya.Spring.Host.Api.Tests/Auth/ApiTokenAuthHandlerTests.cs
@@ -1,10 +1,5 @@
-/*
- * Copyright CVOYA LLC.
- *
- * This source code is proprietary and confidential.
- * Unauthorized copying, modification, distribution, or use of this file,
- * via any medium, is strictly prohibited without the prior written consent of CVOYA LLC.
- */
+// Copyright CVOYA LLC. Licensed under the Business Source License 1.1.
+// See LICENSE.md in the project root for full license terms.
 
 namespace Cvoya.Spring.Host.Api.Tests.Auth;
 

--- a/tests/Cvoya.Spring.Host.Api.Tests/Auth/AuthEndpointsTests.cs
+++ b/tests/Cvoya.Spring.Host.Api.Tests/Auth/AuthEndpointsTests.cs
@@ -1,10 +1,5 @@
-/*
- * Copyright CVOYA LLC.
- *
- * This source code is proprietary and confidential.
- * Unauthorized copying, modification, distribution, or use of this file,
- * via any medium, is strictly prohibited without the prior written consent of CVOYA LLC.
- */
+// Copyright CVOYA LLC. Licensed under the Business Source License 1.1.
+// See LICENSE.md in the project root for full license terms.
 
 namespace Cvoya.Spring.Host.Api.Tests.Auth;
 

--- a/tests/Cvoya.Spring.Host.Api.Tests/Auth/OAuthEndpointsTests.cs
+++ b/tests/Cvoya.Spring.Host.Api.Tests/Auth/OAuthEndpointsTests.cs
@@ -1,10 +1,5 @@
-/*
- * Copyright CVOYA LLC.
- *
- * This source code is proprietary and confidential.
- * Unauthorized copying, modification, distribution, or use of this file,
- * via any medium, is strictly prohibited without the prior written consent of CVOYA LLC.
- */
+// Copyright CVOYA LLC. Licensed under the Business Source License 1.1.
+// See LICENSE.md in the project root for full license terms.
 
 namespace Cvoya.Spring.Host.Api.Tests.Auth;
 

--- a/tests/Cvoya.Spring.Host.Api.Tests/CustomWebApplicationFactory.cs
+++ b/tests/Cvoya.Spring.Host.Api.Tests/CustomWebApplicationFactory.cs
@@ -1,10 +1,5 @@
-/*
- * Copyright CVOYA LLC.
- *
- * This source code is proprietary and confidential.
- * Unauthorized copying, modification, distribution, or use of this file,
- * via any medium, is strictly prohibited without the prior written consent of CVOYA LLC.
- */
+// Copyright CVOYA LLC. Licensed under the Business Source License 1.1.
+// See LICENSE.md in the project root for full license terms.
 
 namespace Cvoya.Spring.Host.Api.Tests;
 

--- a/tests/Cvoya.Spring.Host.Api.Tests/DirectoryEndpointsTests.cs
+++ b/tests/Cvoya.Spring.Host.Api.Tests/DirectoryEndpointsTests.cs
@@ -1,10 +1,5 @@
-/*
- * Copyright CVOYA LLC.
- *
- * This source code is proprietary and confidential.
- * Unauthorized copying, modification, distribution, or use of this file,
- * via any medium, is strictly prohibited without the prior written consent of CVOYA LLC.
- */
+// Copyright CVOYA LLC. Licensed under the Business Source License 1.1.
+// See LICENSE.md in the project root for full license terms.
 
 namespace Cvoya.Spring.Host.Api.Tests;
 

--- a/tests/Cvoya.Spring.Host.Api.Tests/HealthEndpointTests.cs
+++ b/tests/Cvoya.Spring.Host.Api.Tests/HealthEndpointTests.cs
@@ -1,10 +1,5 @@
-/*
- * Copyright CVOYA LLC.
- *
- * This source code is proprietary and confidential.
- * Unauthorized copying, modification, distribution, or use of this file,
- * via any medium, is strictly prohibited without the prior written consent of CVOYA LLC.
- */
+// Copyright CVOYA LLC. Licensed under the Business Source License 1.1.
+// See LICENSE.md in the project root for full license terms.
 
 namespace Cvoya.Spring.Host.Api.Tests;
 

--- a/tests/Cvoya.Spring.Host.Api.Tests/MessageEndpointsTests.cs
+++ b/tests/Cvoya.Spring.Host.Api.Tests/MessageEndpointsTests.cs
@@ -1,10 +1,5 @@
-/*
- * Copyright CVOYA LLC.
- *
- * This source code is proprietary and confidential.
- * Unauthorized copying, modification, distribution, or use of this file,
- * via any medium, is strictly prohibited without the prior written consent of CVOYA LLC.
- */
+// Copyright CVOYA LLC. Licensed under the Business Source License 1.1.
+// See LICENSE.md in the project root for full license terms.
 
 namespace Cvoya.Spring.Host.Api.Tests;
 

--- a/tests/Cvoya.Spring.Integration.Tests/AgentMailboxRoutingTests.cs
+++ b/tests/Cvoya.Spring.Integration.Tests/AgentMailboxRoutingTests.cs
@@ -1,10 +1,5 @@
-/*
- * Copyright CVOYA LLC.
- *
- * This source code is proprietary and confidential.
- * Unauthorized copying, modification, distribution, or use of this file,
- * via any medium, is strictly prohibited without the prior written consent of CVOYA LLC.
- */
+// Copyright CVOYA LLC. Licensed under the Business Source License 1.1.
+// See LICENSE.md in the project root for full license terms.
 
 namespace Cvoya.Spring.Integration.Tests;
 

--- a/tests/Cvoya.Spring.Integration.Tests/CliEndToEndTests.cs
+++ b/tests/Cvoya.Spring.Integration.Tests/CliEndToEndTests.cs
@@ -1,10 +1,5 @@
-/*
- * Copyright CVOYA LLC.
- *
- * This source code is proprietary and confidential.
- * Unauthorized copying, modification, distribution, or use of this file,
- * via any medium, is strictly prohibited without the prior written consent of CVOYA LLC.
- */
+// Copyright CVOYA LLC. Licensed under the Business Source License 1.1.
+// See LICENSE.md in the project root for full license terms.
 
 namespace Cvoya.Spring.Integration.Tests;
 

--- a/tests/Cvoya.Spring.Integration.Tests/ConversationLifecycleTests.cs
+++ b/tests/Cvoya.Spring.Integration.Tests/ConversationLifecycleTests.cs
@@ -1,10 +1,5 @@
-/*
- * Copyright CVOYA LLC.
- *
- * This source code is proprietary and confidential.
- * Unauthorized copying, modification, distribution, or use of this file,
- * via any medium, is strictly prohibited without the prior written consent of CVOYA LLC.
- */
+// Copyright CVOYA LLC. Licensed under the Business Source License 1.1.
+// See LICENSE.md in the project root for full license terms.
 
 namespace Cvoya.Spring.Integration.Tests;
 

--- a/tests/Cvoya.Spring.Integration.Tests/GitHubWebhookFlowTests.cs
+++ b/tests/Cvoya.Spring.Integration.Tests/GitHubWebhookFlowTests.cs
@@ -1,10 +1,5 @@
-/*
- * Copyright CVOYA LLC.
- *
- * This source code is proprietary and confidential.
- * Unauthorized copying, modification, distribution, or use of this file,
- * via any medium, is strictly prohibited without the prior written consent of CVOYA LLC.
- */
+// Copyright CVOYA LLC. Licensed under the Business Source License 1.1.
+// See LICENSE.md in the project root for full license terms.
 
 namespace Cvoya.Spring.Integration.Tests;
 

--- a/tests/Cvoya.Spring.Integration.Tests/TestHelpers/ActorTestHost.cs
+++ b/tests/Cvoya.Spring.Integration.Tests/TestHelpers/ActorTestHost.cs
@@ -1,10 +1,5 @@
-/*
- * Copyright CVOYA LLC.
- *
- * This source code is proprietary and confidential.
- * Unauthorized copying, modification, distribution, or use of this file,
- * via any medium, is strictly prohibited without the prior written consent of CVOYA LLC.
- */
+// Copyright CVOYA LLC. Licensed under the Business Source License 1.1.
+// See LICENSE.md in the project root for full license terms.
 
 namespace Cvoya.Spring.Integration.Tests.TestHelpers;
 

--- a/tests/Cvoya.Spring.Integration.Tests/TestHelpers/MessageFactory.cs
+++ b/tests/Cvoya.Spring.Integration.Tests/TestHelpers/MessageFactory.cs
@@ -1,10 +1,5 @@
-/*
- * Copyright CVOYA LLC.
- *
- * This source code is proprietary and confidential.
- * Unauthorized copying, modification, distribution, or use of this file,
- * via any medium, is strictly prohibited without the prior written consent of CVOYA LLC.
- */
+// Copyright CVOYA LLC. Licensed under the Business Source License 1.1.
+// See LICENSE.md in the project root for full license terms.
 
 namespace Cvoya.Spring.Integration.Tests.TestHelpers;
 

--- a/tests/Cvoya.Spring.Integration.Tests/UnitOrchestrationTests.cs
+++ b/tests/Cvoya.Spring.Integration.Tests/UnitOrchestrationTests.cs
@@ -1,10 +1,5 @@
-/*
- * Copyright CVOYA LLC.
- *
- * This source code is proprietary and confidential.
- * Unauthorized copying, modification, distribution, or use of this file,
- * via any medium, is strictly prohibited without the prior written consent of CVOYA LLC.
- */
+// Copyright CVOYA LLC. Licensed under the Business Source License 1.1.
+// See LICENSE.md in the project root for full license terms.
 
 namespace Cvoya.Spring.Integration.Tests;
 


### PR DESCRIPTION
## Summary

- Add `LICENSE.md` with BSL 1.1 terms (Licensor: CVOYA LLC, Change Date: 2030-04-10, Change License: Apache 2.0)
- Add `NOTICE.md` with copyright notice and third-party dependency attributions
- Replace proprietary copyright headers with BSL 1.1 headers across all 131 source files
- Update `CONVENTIONS.md` with the new copyright header format
- Add License section to `README.md`
- Audit all NuGet dependencies for license compatibility (all permissive: Apache 2.0, MIT, PostgreSQL License)

**Additional Use Grant:** Production use allowed except offering it as a competing managed AI agent orchestration service.

## Test plan

- [x] `dotnet build` passes with 0 warnings, 0 errors
- [ ] Verify GitHub renders LICENSE.md correctly on repo page
- [ ] Verify no source files retain old proprietary header (`grep -r "proprietary and confidential"`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)