### PR TITLE
Bump dependencies: Dapr SDK, Octokit, CodeCoverage, CodeQL action

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -30,7 +30,7 @@ jobs:
           dotnet-version: "10.0.x"
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3
+        uses: github/codeql-action/init@v4
         with:
           languages: csharp
           build-mode: manual
@@ -39,6 +39,6 @@ jobs:
         run: dotnet build SpringVoyage.slnx --configuration Release
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v3
+        uses: github/codeql-action/analyze@v4
         with:
           category: "/language:csharp"

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,14 +4,14 @@
   </PropertyGroup>
   <ItemGroup>
     <!-- Dapr SDK -->
-    <PackageVersion Include="Dapr.Client" Version="1.15.3" />
-    <PackageVersion Include="Dapr.AspNetCore" Version="1.15.3" />
-    <PackageVersion Include="Dapr.Actors" Version="1.15.3" />
-    <PackageVersion Include="Dapr.Actors.AspNetCore" Version="1.15.3" />
+    <PackageVersion Include="Dapr.Client" Version="1.17.8" />
+    <PackageVersion Include="Dapr.AspNetCore" Version="1.17.8" />
+    <PackageVersion Include="Dapr.Actors" Version="1.17.8" />
+    <PackageVersion Include="Dapr.Actors.AspNetCore" Version="1.17.8" />
     <PackageVersion Include="Dapr.Workflow" Version="1.17.8" />
 
     <!-- GitHub -->
-    <PackageVersion Include="Octokit" Version="13.0.1" />
+    <PackageVersion Include="Octokit" Version="14.0.0" />
     <PackageVersion Include="System.IdentityModel.Tokens.Jwt" Version="8.17.0" />
 
     <!-- CLI -->
@@ -32,7 +32,7 @@
 
     <!-- Testing (Microsoft Testing Platform + xUnit v3) -->
     <PackageVersion Include="xunit.v3.mtp-v2" Version="3.2.2" />
-    <PackageVersion Include="Microsoft.Testing.Extensions.CodeCoverage" Version="18.5.2" />
+    <PackageVersion Include="Microsoft.Testing.Extensions.CodeCoverage" Version="18.6.2" />
     <PackageVersion Include="FluentAssertions" Version="8.9.0" />
     <PackageVersion Include="NSubstitute" Version="5.3.0" />
   </ItemGroup>


### PR DESCRIPTION
## Summary

Combines Dependabot PRs #17, #20, #21, #22, #25, #26 into a single change to resolve rebase conflicts between overlapping PRs.

- `github/codeql-action`: v3 → v4
- `Dapr.Client`: 1.15.3 → 1.17.8
- `Dapr.AspNetCore`: 1.15.3 → 1.17.8
- `Dapr.Actors`: 1.15.3 → 1.17.8
- `Dapr.Actors.AspNetCore`: 1.15.3 → 1.17.8
- `Octokit`: 13.0.1 → 14.0.0
- `Microsoft.Testing.Extensions.CodeCoverage`: 18.5.2 → 18.6.2

All Dapr packages are now aligned at 1.17.8 (including Dapr.Workflow from #23).

## Test plan
- [ ] CI build passes
- [ ] All tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)