### PR TITLE
Add extensibility guidance to agent instructions for OSS/private two-repo model

### DIFF
--- a/.cursor/rules/spring-v2.mdc
+++ b/.cursor/rules/spring-v2.mdc
@@ -7,10 +7,13 @@ globs: "**"
 
 AI agent orchestration platform built on .NET 10 and Dapr. Namespace: `Cvoya.Spring.*`.
 
+**This is the open-source core platform.** A private repository (Spring Voyage Cloud) extends it via git submodule and DI to add multi-tenancy, OAuth, billing, and premium features. Design every change for clean extensibility — the private repo must be able to override, wrap, or compose OSS behavior without forking or patching.
+
 ## Essential References
 
 - **Full conventions:** `CONVENTIONS.md` (MUST read before writing code)
 - **Architecture plan:** `docs/SpringVoyage-v2-plan.md`
+- **Extensibility model:** `AGENTS.md` § "Open-Source Platform & Extensibility"
 
 ## Quick Rules
 
@@ -22,9 +25,12 @@ AI agent orchestration platform built on .NET 10 and Dapr. Namespace: `Cvoya.Spr
 - **Interface-first:** define in `Cvoya.Spring.Core`, implement in `Cvoya.Spring.Dapr`.
 - **System.Text.Json only.** No Newtonsoft.Json.
 - **Primary constructor injection.** No service locator.
+- **`TryAdd*` for all DI registrations** so the private repo can pre-register overrides.
 - **`Async` suffix** on all async methods. `CancellationToken` as last parameter.
 - **Never let exceptions escape actor turns.** Catch, log, update state.
 - **Use `Result<T, TError>`** for expected failures (routing, resolution).
+- **Don't seal extensible types.** Services, handlers, strategies, and base classes must remain unsealed.
+- **No tenant concepts.** No `TenantId`, no multi-tenancy — the private repo layers that on.
 
 ## Build & Test
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,6 +25,41 @@ dotnet test                        # run all tests
 dotnet format --verify-no-changes  # check formatting
 ```
 
+## Open-Source Platform & Extensibility
+
+This is the **public, open-source core** of the Spring Voyage platform. A private repository (Spring Voyage Cloud) extends this codebase via git submodule and dependency injection to add multi-tenancy, OAuth/SSO, billing, and premium features.
+
+**Every design decision in this repo must account for extensibility.** The private repo should be able to extend, override, or compose OSS behavior cleanly — without forking, patching, or working around limitations. Think of this repo as a framework that the private repo consumes.
+
+### Extension Model
+
+The private repo extends the OSS platform through dependency injection:
+
+- **Tenant-scoped wrappers** around OSS repositories and services (the OSS codebase has no concept of tenants or `TenantId`)
+- **DI overrides** — the cloud host replaces OSS service registrations with tenant-aware implementations
+- **Additional actors, strategies, and connectors** that compose OSS building blocks
+- **Cloud API host** that layers middleware (auth, tenant context) on top of the OSS API host
+
+### Design Principles for Extensibility
+
+1. **Interface-first, always.** Define interfaces in `Cvoya.Spring.Core`, implement in `Cvoya.Spring.Dapr`. The private repo can provide alternative implementations without touching OSS code.
+2. **Use `TryAdd*` for DI registrations.** Use `TryAddSingleton`, `TryAddScoped`, etc. so the private repo can register its own implementations before calling `AddCvoyaSpring*()`, and OSS registrations won't overwrite them. For keyed services, check before registering.
+3. **Don't seal extensible types.** Classes that represent extension points (services, handlers, strategies, middleware) should not be `sealed` unless there is a specific reason. Mark them `sealed` only for leaf types that are not designed for inheritance.
+4. **Favor composition over inheritance.** Prefer injecting collaborators over deep class hierarchies. The private repo extends behavior by wrapping or decorating OSS services, not by subclassing.
+5. **No hardcoded assumptions about single-tenancy.** Don't embed assumptions like "there's one user" or "one set of config." Use injected services for anything that the private repo might scope per-tenant (repositories, configuration, policies).
+6. **Virtual methods on base classes.** When providing base classes (e.g., `ConnectorBase`, `ActorBase`), make hook/template methods `virtual` so the private repo can override behavior.
+7. **Keep `Cvoya.Spring.Core` dependency-free.** It defines the domain contract. The private repo depends on these abstractions directly without pulling in infrastructure packages.
+8. **Extension point checklist.** When adding a new feature, ask:
+   - Can the private repo swap this implementation via DI? → Use an interface.
+   - Can the private repo extend this behavior? → Use decorator/wrapper pattern or virtual methods.
+   - Does this assume a single deployment context? → Parameterize via injected configuration/services.
+
+### What NOT to Do
+
+- **Don't reference tenant concepts.** No `TenantId`, no multi-tenancy awareness. The private repo layers that on.
+- **Don't make services static or use singletons outside DI.** Everything must go through the container so the private repo can control lifetime and scoping.
+- **Don't create internal types that the private repo would need to access.** If a type is part of the extension contract, make it `public`. Use `internal` only for true implementation details.
+
 ## Key Rules
 
 - `Cvoya.Spring.Core` must have ZERO external NuGet package references. It defines domain abstractions only.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,8 @@
 # Spring Voyage V2 — Claude Code Configuration
 
-Read `AGENTS.md` for project rules and architecture. Read `CONVENTIONS.md` for coding patterns. Both are mandatory.
+Read `AGENTS.md` for project rules, architecture, and **extensibility requirements**. Read `CONVENTIONS.md` for coding patterns. Both are mandatory.
+
+This is the **open-source core platform**. A private repository extends it via git submodule and DI. Every change must be designed for clean extension — read `AGENTS.md` § "Open-Source Platform & Extensibility" before starting work.
 
 Before working on an issue, read the relevant sections of `docs/SpringVoyage-v2-plan.md`.
 

--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -129,6 +129,15 @@ public static class ServiceCollectionExtensions
   services.AddKeyedSingleton<IOrchestrationStrategy, AiOrchestrationStrategy>("ai");
   services.AddKeyedSingleton<IOrchestrationStrategy, WorkflowOrchestrationStrategy>("workflow");
   ```
+- **Use `TryAdd*` for all service registrations** so downstream consumers (e.g., the private cloud repo) can override implementations by registering their own before calling `AddCvoyaSpring*()`:
+  ```csharp
+  public static IServiceCollection AddCvoyaSpringDapr(this IServiceCollection services)
+  {
+      services.TryAddSingleton<IMessageRouter, MessageRouter>();
+      services.TryAddScoped<IDirectoryService, DaprDirectoryService>();
+      return services;
+  }
+  ```
 - Registration in `Program.cs`:
   ```csharp
   builder.Services
@@ -317,3 +326,19 @@ Multiple agents work on v2 simultaneously. Follow these rules:
 ```
 
 **Central package management** via `Directory.Packages.props` — all NuGet versions pinned centrally.
+
+## 13. Extensibility Conventions
+
+This repo is the OSS core of a two-repo model. A private repository extends it via DI and git submodule. All code must be designed for clean extension. See `AGENTS.md` § "Open-Source Platform & Extensibility" for the full rationale.
+
+**Service registration:** Always use `TryAdd*` (`TryAddSingleton`, `TryAddScoped`, `TryAddTransient`). This lets the private repo pre-register overrides.
+
+**Sealing policy:** Don't `seal` services, handlers, base classes, or strategy implementations. Seal only leaf types that are not extension points (e.g., record DTOs, internal helpers).
+
+**Visibility:** Types that are part of the extension contract must be `public`. Use `internal` only for true implementation details that no consumer would ever need to access or replace.
+
+**Base class hooks:** When creating base classes (`ConnectorBase`, `ActorBase`, etc.), make template/hook methods `protected virtual` so they can be overridden.
+
+**No tenant assumptions:** Don't embed single-user or single-deployment assumptions. Use injected services for anything the private repo might scope per-tenant: repositories, configuration providers, policy evaluators.
+
+**No statics for state or services:** Everything goes through DI. No static service locators, no ambient contexts, no `static` mutable state.


### PR DESCRIPTION
## Summary

- Adds an **Open-Source Platform & Extensibility** section to `AGENTS.md` covering the two-repo model (public `spring-voyage` + private Spring Voyage Cloud), the extension model (DI overrides, tenant-scoped wrappers, cloud API host), 8 design principles for extensibility, and explicit anti-patterns.
- Updates `CONVENTIONS.md` with a `TryAdd*` DI registration rule (with code example) and a new Section 13: Extensibility Conventions (sealing policy, visibility, base class hooks, no tenant assumptions, no statics).
- Updates `.cursor/rules/spring-v2.mdc` with the OSS context statement and three new quick rules (`TryAdd*`, don't seal extensible types, no tenant concepts).
- Updates `CLAUDE.md` to direct agents to read the extensibility requirements before starting work.

## Test plan

- [ ] Verify all four files render correctly in GitHub markdown
- [ ] Confirm agents working in this repo pick up the extensibility guidance
- [ ] Confirm no unrelated changes were introduced


Made with [Cursor](https://cursor.com)