### PR TITLE
Add conversation chat UI to portal (closes #410)

### DIFF
--- a/docs/architecture/messaging.md
+++ b/docs/architecture/messaging.md
@@ -265,3 +265,22 @@ All actors have **flat, globally-unique Dapr actor IDs** derived from their UUID
 Topics are namespaced by unit: `engineering-team/pr-reviews`, `research-team/papers/new-arxiv`.
 
 Dapr pub/sub is broker-agnostic — Redis for development, Kafka or Azure Event Hubs for production, swapped via YAML.
+
+---
+
+## Conversation Surfaces
+
+A conversation is **not a stored entity** — it is a projection over the activity event stream. Every message envelope persists its `ConversationId` as the `CorrelationId` on the resulting observability event; `IConversationQueryService` materialises summaries, threads, and inbox rows by grouping events on that id. See `src/Cvoya.Spring.Core/Observability/ConversationQueryModels.cs` for the projection contract and `src/Cvoya.Spring.Host.Api/Endpoints/ConversationEndpoints.cs` for the HTTP surface.
+
+The same projection feeds two equivalent surfaces:
+
+| Surface       | CLI                                                              | Portal                                                                                            |
+| ------------- | ---------------------------------------------------------------- | ------------------------------------------------------------------------------------------------- |
+| List          | `spring conversation list [--unit] [--agent] [--status] [--participant]` | `/conversations` (with the same query-string filter shape; see `src/Cvoya.Spring.Web/src/app/conversations/page.tsx`). |
+| Show          | `spring conversation show <id>`                                  | `/conversations/<id>` — full role-attributed thread (#410).                                       |
+| Send          | `spring conversation send --conversation <id> <addr> <text>`     | Composer at the bottom of `/conversations/<id>`.                                                  |
+| Inbox         | `spring inbox list`                                              | "Awaiting you" panel on `/conversations`.                                                         |
+
+The portal is **not** a separate event source. It consumes the activity SSE stream (`/api/stream/activity`, see [Streaming](#streaming-real-time-output-from-execution-environments)) and uses the same conversation endpoints the CLI consumes — there is no portal-only data path. UI/CLI parity is enforced by `CONVENTIONS.md § ui-cli-parity` and validated by `npm test` and `dotnet test`.
+
+The conversation thread view cross-links each event back to the activity surface (`/activity?source=…`) and the activity surface deep-links any event with a non-null `correlationId` into `/conversations/<id>`. The two surfaces stay separate by design — activity is the raw timeline, conversations is the chat-shaped projection — but they share the underlying stream and are always one click apart. See `docs/design/portal-exploration.md` § 5.3 for the wireframes.

--- a/docs/guide/portal.md
+++ b/docs/guide/portal.md
@@ -20,13 +20,14 @@ Authentication uses the same token flow as the CLI: when the API Host is running
 
 ## Navigation and shell
 
-The left sidebar ([src/Cvoya.Spring.Web/src/components/sidebar.tsx](../../src/Cvoya.Spring.Web/src/components/sidebar.tsx)) is the top-level navigator. It currently exposes five entries:
+The left sidebar ([src/Cvoya.Spring.Web/src/components/sidebar.tsx](../../src/Cvoya.Spring.Web/src/components/sidebar.tsx)) is the top-level navigator. It currently exposes six entries:
 
 | Portal route | What it shows | Primary CLI equivalent |
 |--------------|---------------|------------------------|
 | `/` — **Dashboard** | Stats header, unit cards, agent cards, recent activity | (no single CLI equivalent — see individual pages) |
 | `/units` — **Units** | List of all units with status + delete action | `spring unit list` |
 | `/activity` — **Activity** | Paginated activity feed with filters | `spring activity list` |
+| `/conversations` — **Conversations** | Filtered conversation list, "Awaiting you" inbox, deep links to threads | `spring conversation list` / `spring inbox list` |
 | `/initiative` — **Initiative** | Per-agent initiative policy editor + recent initiative events | (no CLI equivalent today — parity gap) |
 | `/budgets` — **Budgets** | Tenant daily budget + per-agent budget rows | (no CLI equivalent today — parity gap) |
 
@@ -248,6 +249,50 @@ spring activity list --severity Warning
 spring activity list --limit 50
 ```
 
+## Conversations (`/conversations`, `/conversations/{id}`)
+
+The conversations surface ([src/Cvoya.Spring.Web/src/app/conversations/](../../src/Cvoya.Spring.Web/src/app/conversations/)) is the chat-shaped projection over the activity event stream. A "conversation" is the set of activity events that share a `correlationId` (which the platform sets to the message envelope's `ConversationId` — see [Messaging — Conversation Surfaces](../architecture/messaging.md#conversation-surfaces)).
+
+### List (`/conversations`)
+
+The list page is the one-to-one portal counterpart of `spring conversation list`:
+
+- **Filters** — `unit`, `agent`, `participant`, and `status` (`active` / `completed`). Filter values live in the URL query string, so a link like `/conversations?unit=engineering-team&status=active` round-trips with the CLI's `--unit engineering-team --status active`.
+- **"Awaiting you"** — at the top, the inbox panel renders the rows returned by `GET /api/v1/inbox` (the same data feeding `spring inbox list`). Each row deep-links to the relevant conversation.
+- **Conversation grid** — one `<ConversationCard>` per row, showing the participants, status, last-activity time, and a one-click "Open" link.
+- **Live updates** — the page subscribes to the activity SSE stream (`/api/stream/activity`); whenever a relevant event lands, the list is invalidated and refetched. There is no polling.
+
+| Action | Portal | CLI |
+|--------|--------|-----|
+| List conversations | `/conversations` | `spring conversation list` |
+| Filter by unit | `?unit=…` | `--unit …` |
+| Filter by agent | `?agent=…` | `--agent …` |
+| Filter by participant | `?participant=scheme://path` | `--participant scheme://path` |
+| Filter by status | `?status=active|completed` | `--status active|completed` |
+| Inbox (awaiting me) | "Awaiting you" panel | `spring inbox list` |
+
+### Thread (`/conversations/{id}`)
+
+The thread page is the one-to-one portal counterpart of `spring conversation show <id>` — plus a composer that mirrors `spring conversation send --conversation <id> <addr> <text>`.
+
+- **Header** — conversation id, status, summary, participants, "Origin" address (a link back to `/activity?source=…` so users can pivot to the raw event log), and a "View activity" button that filters the activity surface by this conversation.
+- **Thread** — one bubble per `ConversationEvent`, with role attribution by source scheme:
+  - `human://` — right-aligned, primary surface (the human's voice).
+  - `agent://` — left-aligned, muted surface.
+  - `unit://` — left-aligned, dimmer muted surface.
+  - `system://` — left-aligned, italic muted surface.
+  - `DecisionMade` events render as left-aligned **tool calls** with an amber outline; they collapse by default to keep the thread readable. `StateChanged`, `WorkflowStepCompleted`, and `ReflectionCompleted` also collapse by default.
+  - Each bubble carries a "View in activity →" link to deep-link back to the activity surface, the inverse of the activity row's "Open thread" pill.
+- **Composer** — a textarea + recipient field at the bottom of the thread. The recipient is seeded with the most-recently-active non-human participant and can be changed via quick-pick pills. Submit on click or `⌘/Ctrl+Enter`. The composer POSTs to `/api/v1/conversations/{id}/messages` exactly like the CLI's `spring conversation send`.
+- **Live updates** — the page subscribes to the activity SSE stream filtered by `correlationId`; new events appear in the thread as they land, with no manual refresh.
+
+| Action | Portal | CLI |
+|--------|--------|-----|
+| Show a thread | `/conversations/{id}` | `spring conversation show <id>` |
+| Send into a thread | composer at the bottom of `/conversations/{id}` | `spring conversation send --conversation <id> <addr> <text>` |
+| Jump to activity event | "View in activity →" on any bubble | — |
+| Jump to thread from an activity row | "Open thread" pill on rows with a correlation id | — |
+
 ## Initiative (`/initiative`)
 
 The initiative page ([src/Cvoya.Spring.Web/src/app/initiative/page.tsx](../../src/Cvoya.Spring.Web/src/app/initiative/page.tsx)) lists every agent with its current initiative `level` and policy `maxLevel`. Clicking an agent opens an inline policy editor where you set:
@@ -341,7 +386,7 @@ Today's portal has capabilities not mirrored in the CLI, and vice versa. These a
 | `spring apply` for YAML manifests | not implemented | `spring apply -f` | |
 | Activity streaming (live follow) | polling refresh | not implemented | neither surface has a real-time `activity stream` today |
 | Cost summary / budget CLI | — | not implemented | the older `docs/guide/observing.md` references `spring cost summary`/`spring cost budget`/`spring activity stream` which are not on the shipped CLI surface |
-| Messaging UI | not implemented | `spring message send` | portal is observe-only for messages |
+| Messaging UI (one-shot send to an arbitrary address) | not implemented | `spring message send` | use the conversation composer for in-thread replies; new-conversation send is still CLI-only |
 
 Parity is a project norm (see the top-level `AGENTS.md`): any time you find yourself building a feature on one surface, file a follow-up to bring the other in line.
 

--- a/src/Cvoya.Spring.Web/DESIGN.md
+++ b/src/Cvoya.Spring.Web/DESIGN.md
@@ -260,13 +260,25 @@ The portal's primitive library lives in `src/components/ui/`. Shared composites 
 - Nav item: `flex items-center gap-2 rounded-md px-3 py-2 text-sm transition-colors`. Active: `bg-primary/10 text-primary font-medium`. Inactive: `text-muted-foreground hover:bg-accent hover:text-accent-foreground`.
 - Brand wordmark is `text-lg font-bold` ("Spring Voyage"). Version chip is `text-xs text-muted-foreground` in the footer, paired with the theme toggle (`Sun` / `Moon` at `h-3.5 w-3.5`).
 
-### 7.11 Cards for domain entities — `stat-card.tsx`, `unit-card.tsx`, `agent-card.tsx`, `activity-feed.tsx`
+### 7.11 Cards for domain entities — `stat-card.tsx`, `unit-card.tsx`, `agent-card.tsx`, `activity-feed.tsx`, `conversation-card.tsx`
 
 - Stat card: label (`text-xs text-muted-foreground`) + value (`text-2xl font-bold`) + trailing icon (`text-muted-foreground`).
 - Unit / agent cards compose the base `Card` with a status dot + name + registered-at row.
 - Activity feed row: `flex items-start gap-2 text-sm` with a 2×2 severity dot at `mt-1.5`, message on top, meta (`text-xs text-muted-foreground`) below.
+- Conversation card (`components/cards/conversation-card.tsx`): MessagesSquare icon + title + status badge on the top row; truncated participants (max 3, `+N more` overflow) and `timeAgo(lastActivityAt)` on the meta row; trailing "Open" link to `/conversations/[id]`.
 
-### 7.12 Icons
+### 7.12 Conversation thread — `app/conversations/[id]/`, `components/conversation/`
+
+The conversation surface (#410) renders a chat-style thread with role-attributed bubbles and a CLI-shaped composer. Layout primitives:
+
+- **Role bubbles** (`components/conversation/conversation-event-row.tsx`): `human://` is right-aligned in `bg-primary text-primary-foreground`; `agent://` left-aligned in `bg-muted`; `unit://` left-aligned in `bg-muted/60`; `tool` (events of type `DecisionMade`) left-aligned with an amber outline (`bg-amber-50 text-amber-900 border border-amber-200`); `system` left-aligned in `bg-muted/40 italic`.
+- **Tool calls and lifecycle events** (`StateChanged`, `WorkflowStepCompleted`, `ReflectionCompleted`) collapse by default with a chevron toggle; messages stay expanded so the thread reads like a chat. The collapsed call-out shows the event type and its summary on a single truncated line.
+- **Bubble meta**: role pill (`Badge variant="outline"` at `h-5 px-1.5 text-[10px]`) + monospace source + relative time, mirrored to the same alignment as the bubble.
+- **Composer** (`components/conversation/conversation-composer.tsx`): recipient input (monospace, `scheme://path` placeholder) above a textarea. Quick-pick participant pills sit above the input so users can re-target without typing. Submit on click or `⌘/Ctrl+Enter`. Mirrors the two CLI arguments `spring conversation send` takes.
+- **Thread shell** (`app/conversations/[id]/conversation-detail-client.tsx`): scrollable thread (`max-h-[60vh] overflow-y-auto`) with `aria-live="polite"` so screen readers announce new events as the SSE stream lands them. Auto-scrolls to the bottom on new event.
+- **Cross-links**: the conversation header's `Origin` is a link to `/activity?source=…`, and the activity row's correlation id renders an "Open thread" pill that deep-links to `/conversations/[id]`.
+
+### 7.13 Icons
 
 - [`lucide-react`](https://lucide.dev). Sizes: `h-3 w-3` (inline meta), `h-3.5 w-3.5` (theme toggle), `h-4 w-4` (button icon, card section icon, severity dot wrapper), `h-5 w-5` (sidebar mobile menu, page H1 icon), `h-10 w-10` (empty-state icon).
 - Icons in CTAs never carry colour — they inherit `currentColor` from the surrounding text.

--- a/src/Cvoya.Spring.Web/src/app/activity/page.tsx
+++ b/src/Cvoya.Spring.Web/src/app/activity/page.tsx
@@ -1,11 +1,13 @@
 "use client";
 
 import { useMemo, useState } from "react";
+import Link from "next/link";
 import {
   Activity,
   ChevronDown,
   ChevronRight,
   ChevronLeft,
+  MessagesSquare,
   RefreshCw,
 } from "lucide-react";
 
@@ -103,9 +105,21 @@ function EventRow({
             <span className="font-mono text-xs">{event.id}</span>
           </div>
           {event.correlationId && (
-            <div className="flex gap-2">
+            <div className="flex items-center gap-2">
               <span className="text-muted-foreground">Correlation ID:</span>
               <span className="font-mono text-xs">{event.correlationId}</span>
+              {/* Activity events that carry a correlation id are part
+                  of a conversation thread (#410). The conversations
+                  surface is keyed on that id so we surface a
+                  one-click jump straight into the thread view. */}
+              <Link
+                href={`/conversations/${encodeURIComponent(event.correlationId)}`}
+                className="inline-flex items-center gap-1 rounded border border-input bg-background px-2 py-0.5 text-xs text-primary hover:bg-accent"
+                aria-label="Open conversation thread"
+              >
+                <MessagesSquare className="h-3 w-3" />
+                Open thread
+              </Link>
             </div>
           )}
           {event.cost != null && (

--- a/src/Cvoya.Spring.Web/src/app/agents/[id]/agent-detail-client.tsx
+++ b/src/Cvoya.Spring.Web/src/app/agents/[id]/agent-detail-client.tsx
@@ -3,9 +3,11 @@
 import { useCallback, useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 import { useQueryClient } from "@tanstack/react-query";
+import Link from "next/link";
 import {
   Copy,
   DollarSign,
+  MessagesSquare,
   Plus,
   Trash2,
   Wallet,
@@ -282,6 +284,25 @@ export default function AgentDetailClient({ id }: ClientProps) {
           <Trash2 className="mr-1 h-4 w-4" /> Delete
         </Button>
       </div>
+
+      {/* Quick link to the conversation surface filtered by this agent
+          (#410). Mirrors `spring conversation list --agent <name>` so
+          the portal exposes the same one-click jump. */}
+      <Card>
+        <CardContent className="flex items-center justify-between gap-3 py-4 text-sm">
+          <div className="flex items-center gap-2">
+            <MessagesSquare className="h-4 w-4 text-muted-foreground" />
+            <span>Conversations involving this agent</span>
+          </div>
+          <Link
+            href={`/conversations?agent=${encodeURIComponent(agent.name)}`}
+            className="inline-flex items-center gap-1 rounded-md border border-input bg-background px-3 py-1 text-xs font-medium text-primary hover:bg-accent"
+            data-testid="agent-conversations-link"
+          >
+            View threads →
+          </Link>
+        </CardContent>
+      </Card>
 
       <Card>
         <CardHeader>

--- a/src/Cvoya.Spring.Web/src/app/conversations/[id]/conversation-detail-client.test.tsx
+++ b/src/Cvoya.Spring.Web/src/app/conversations/[id]/conversation-detail-client.test.tsx
@@ -1,0 +1,176 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import type { ReactNode } from "react";
+
+import { ConversationDetailClient } from "./conversation-detail-client";
+
+const mockGetConversation = vi.fn();
+const mockSendConversationMessage = vi.fn();
+
+vi.mock("@/lib/api/client", () => ({
+  api: {
+    getConversation: (...args: unknown[]) => mockGetConversation(...args),
+    sendConversationMessage: (...args: unknown[]) =>
+      mockSendConversationMessage(...args),
+  },
+}));
+
+vi.mock("@/lib/stream/use-activity-stream", () => ({
+  useActivityStream: () => ({ events: [], connected: false }),
+}));
+
+vi.mock("next/link", () => ({
+  default: ({
+    href,
+    children,
+    ...rest
+  }: {
+    href: string;
+    children: React.ReactNode;
+  } & Record<string, unknown>) => (
+    <a href={href} {...rest}>
+      {children}
+    </a>
+  ),
+}));
+
+const baseConversation = {
+  summary: {
+    id: "conv-42",
+    participants: ["human://savas", "agent://ada"],
+    status: "active",
+    lastActivity: new Date().toISOString(),
+    createdAt: new Date().toISOString(),
+    eventCount: 3,
+    origin: "human://savas",
+    summary: "PR review thread",
+  },
+  events: [
+    {
+      id: "00000000-0000-0000-0000-000000000001",
+      timestamp: new Date().toISOString(),
+      source: "human://savas",
+      eventType: "MessageSent",
+      severity: "Info",
+      summary: "Hey can you take a look?",
+    },
+    {
+      id: "00000000-0000-0000-0000-000000000002",
+      timestamp: new Date().toISOString(),
+      source: "agent://ada",
+      eventType: "MessageReceived",
+      severity: "Info",
+      summary: "Sure, looking now.",
+    },
+    {
+      id: "00000000-0000-0000-0000-000000000003",
+      timestamp: new Date().toISOString(),
+      source: "agent://ada",
+      eventType: "DecisionMade",
+      severity: "Info",
+      summary: "Calling code-search tool",
+    },
+  ],
+};
+
+function Wrapper({ children }: { children: ReactNode }) {
+  const client = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, gcTime: 0, staleTime: 0 },
+    },
+  });
+  return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+}
+
+describe("ConversationDetailClient", () => {
+  beforeEach(() => {
+    mockGetConversation.mockReset();
+    mockSendConversationMessage.mockReset();
+    mockGetConversation.mockResolvedValue(baseConversation);
+  });
+
+  it("renders the thread with role-attributed events", async () => {
+    render(
+      <Wrapper>
+        <ConversationDetailClient id="conv-42" />
+      </Wrapper>,
+    );
+    await waitFor(() => {
+      expect(screen.getByText("Hey can you take a look?")).toBeInTheDocument();
+      expect(screen.getByText("Sure, looking now.")).toBeInTheDocument();
+    });
+
+    // The human message bubble carries the human role.
+    const humanRow = screen.getByTestId(
+      "conversation-event-00000000-0000-0000-0000-000000000001",
+    );
+    expect(humanRow).toHaveAttribute("data-role", "human");
+
+    // DecisionMade renders as a tool-call (collapsed by default).
+    const toolRow = screen.getByTestId(
+      "conversation-event-00000000-0000-0000-0000-000000000003",
+    );
+    expect(toolRow).toHaveAttribute("data-role", "tool");
+    expect(
+      toolRow.querySelector('[aria-expanded="false"]'),
+    ).not.toBeNull();
+  });
+
+  it("links the origin to the activity surface", async () => {
+    render(
+      <Wrapper>
+        <ConversationDetailClient id="conv-42" />
+      </Wrapper>,
+    );
+    await waitFor(() => {
+      const originLink = screen.getByLabelText("Open origin in activity log");
+      expect(originLink).toHaveAttribute(
+        "href",
+        "/activity?source=human%3A%2F%2Fsavas",
+      );
+    });
+  });
+
+  it("sends a message via the conversation API on composer submit", async () => {
+    mockSendConversationMessage.mockResolvedValue({
+      messageId: "msg-1",
+      conversationId: "conv-42",
+      responsePayload: null,
+    });
+    render(
+      <Wrapper>
+        <ConversationDetailClient id="conv-42" />
+      </Wrapper>,
+    );
+    await waitFor(() => {
+      expect(screen.getByLabelText("Recipient address")).toBeInTheDocument();
+    });
+
+    fireEvent.change(screen.getByLabelText("Message text"), {
+      target: { value: "Looks good, ship it." },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /send/i }));
+
+    await waitFor(() => {
+      expect(mockSendConversationMessage).toHaveBeenCalledWith("conv-42", {
+        to: { scheme: "agent", path: "ada" },
+        text: "Looks good, ship it.",
+      });
+    });
+  });
+
+  it("shows a not-found state when the API returns null", async () => {
+    mockGetConversation.mockResolvedValue(null);
+    render(
+      <Wrapper>
+        <ConversationDetailClient id="missing" />
+      </Wrapper>,
+    );
+    await waitFor(() => {
+      expect(
+        screen.getByText(/was not found/i),
+      ).toBeInTheDocument();
+    });
+  });
+});

--- a/src/Cvoya.Spring.Web/src/app/conversations/[id]/conversation-detail-client.tsx
+++ b/src/Cvoya.Spring.Web/src/app/conversations/[id]/conversation-detail-client.tsx
@@ -1,0 +1,242 @@
+"use client";
+
+import { useEffect, useMemo, useRef } from "react";
+import Link from "next/link";
+import { ArrowLeft, MessagesSquare, RefreshCw } from "lucide-react";
+
+import { Badge } from "@/components/ui/badge";
+import { Breadcrumbs } from "@/components/breadcrumbs";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+import { useConversation } from "@/lib/api/queries";
+import { useActivityStream } from "@/lib/stream/use-activity-stream";
+import { ConversationComposer } from "@/components/conversation/conversation-composer";
+import { ConversationEventRow } from "@/components/conversation/conversation-event-row";
+import { parseConversationSource } from "@/components/conversation/role";
+import { timeAgo } from "@/lib/utils";
+
+interface ConversationDetailClientProps {
+  id: string;
+}
+
+const STATUS_VARIANTS: Record<
+  string,
+  "default" | "success" | "warning" | "destructive" | "secondary" | "outline"
+> = {
+  active: "success",
+  open: "default",
+  waiting: "warning",
+  "waiting-on-human": "warning",
+  blocked: "warning",
+  completed: "secondary",
+  error: "destructive",
+};
+
+export function ConversationDetailClient({ id }: ConversationDetailClientProps) {
+  const conversationQuery = useConversation(id);
+  const conversation = conversationQuery.data ?? null;
+  const loading = conversationQuery.isPending;
+  const error =
+    conversationQuery.error instanceof Error
+      ? conversationQuery.error.message
+      : null;
+
+  // Live updates: scope the stream to events that share this
+  // conversation id (correlationId === id) OR originate from one of
+  // the participants. We don't strictly need the filter — the
+  // invalidation in `queryKeysAffectedBySource` covers conversation/
+  // human/agent/unit scopes — but filtering keeps the in-memory
+  // events list lean for any future debugging panel.
+  useActivityStream({
+    filter: (event) => event.correlationId === id,
+  });
+
+  // Auto-scroll the thread to the bottom whenever a new event lands.
+  const eventCount = conversation?.events?.length ?? 0;
+  const bottomRef = useRef<HTMLDivElement | null>(null);
+  useEffect(() => {
+    bottomRef.current?.scrollIntoView({ behavior: "smooth" });
+  }, [eventCount]);
+
+  // Pick the most recent non-self speaker as the default reply
+  // recipient. We don't have a "self" concept in the portal yet so
+  // we approximate: prefer the latest event whose source is NOT a
+  // human:// (the human is most likely the current portal user).
+  // Falls back to the first participant.
+  const defaultRecipient = useMemo(() => {
+    if (!conversation) return undefined;
+    const events = conversation.events ?? [];
+    for (let i = events.length - 1; i >= 0; i--) {
+      const src = parseConversationSource(events[i].source);
+      if (src.scheme !== "human") {
+        return src.raw;
+      }
+    }
+    return conversation.summary?.participants?.[0];
+  }, [conversation]);
+
+  const breadcrumbs = (
+    <Breadcrumbs
+      items={[
+        { label: "Conversations", href: "/conversations" },
+        { label: conversation?.summary?.id ?? id },
+      ]}
+    />
+  );
+
+  if (loading) {
+    return (
+      <div className="space-y-4">
+        {breadcrumbs}
+        <Skeleton className="h-10 w-72" />
+        <Skeleton className="h-40" />
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="space-y-4">
+        {breadcrumbs}
+        <p className="rounded-md border border-destructive/50 bg-destructive/10 px-3 py-2 text-sm text-destructive">
+          {error}
+        </p>
+        <Link
+          href="/conversations"
+          className="inline-flex items-center gap-1 text-sm text-primary hover:underline"
+        >
+          <ArrowLeft className="h-3.5 w-3.5" /> Back to conversations
+        </Link>
+      </div>
+    );
+  }
+
+  if (!conversation) {
+    return (
+      <div className="space-y-4">
+        {breadcrumbs}
+        <p className="text-sm text-muted-foreground">
+          Conversation <span className="font-mono">{id}</span> was not found.
+        </p>
+        <Link
+          href="/conversations"
+          className="inline-flex items-center gap-1 text-sm text-primary hover:underline"
+        >
+          <ArrowLeft className="h-3.5 w-3.5" /> Back to conversations
+        </Link>
+      </div>
+    );
+  }
+
+  const summary = conversation.summary;
+  const events = conversation.events ?? [];
+  const statusKey = (summary?.status ?? "").toLowerCase();
+  const statusVariant = STATUS_VARIANTS[statusKey] ?? "outline";
+  const origin = summary?.origin ?? "";
+
+  return (
+    <div className="space-y-4">
+      {breadcrumbs}
+
+      {/* Header */}
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+        <div className="min-w-0 space-y-1">
+          <h1 className="flex items-center gap-2 text-2xl font-bold">
+            <MessagesSquare className="h-5 w-5" />
+            <span className="truncate font-mono text-base">{summary.id}</span>
+          </h1>
+          <p className="text-sm text-muted-foreground">
+            {summary.summary || "No summary available."}
+          </p>
+          <div className="flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
+            {summary.status && (
+              <Badge variant={statusVariant}>{summary.status}</Badge>
+            )}
+            {origin && (
+              <span>
+                Origin:{" "}
+                <Link
+                  href={`/activity?source=${encodeURIComponent(origin)}`}
+                  className="font-mono text-primary hover:underline"
+                  aria-label="Open origin in activity log"
+                >
+                  {origin}
+                </Link>
+              </span>
+            )}
+            <span>Created {timeAgo(summary.createdAt)}</span>
+            <span>Last activity {timeAgo(summary.lastActivity)}</span>
+            <span>
+              {String(summary.eventCount)}{" "}
+              {Number(summary.eventCount) === 1 ? "event" : "events"}
+            </span>
+          </div>
+          {summary.participants && summary.participants.length > 0 && (
+            <div className="flex flex-wrap items-center gap-1 pt-1 text-xs">
+              <span className="text-muted-foreground">Participants:</span>
+              {summary.participants.map((p) => (
+                <Badge key={p} variant="outline" className="font-mono">
+                  {p}
+                </Badge>
+              ))}
+            </div>
+          )}
+        </div>
+        <div className="flex shrink-0 gap-2">
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => conversationQuery.refetch()}
+            disabled={conversationQuery.isFetching}
+          >
+            <RefreshCw
+              className={`h-4 w-4 mr-1 ${
+                conversationQuery.isFetching ? "animate-spin" : ""
+              }`}
+            />
+            Refresh
+          </Button>
+          <Link
+            href={`/activity?correlationId=${encodeURIComponent(id)}`}
+            className="inline-flex h-9 items-center gap-1 rounded-md border border-input bg-background px-3 text-sm font-medium shadow-sm hover:bg-accent"
+          >
+            View activity
+          </Link>
+        </div>
+      </div>
+
+      {/* Thread + composer */}
+      <Card className="flex flex-col">
+        <CardHeader className="border-b border-border py-3">
+          <CardTitle className="text-sm">Thread</CardTitle>
+        </CardHeader>
+        <CardContent className="p-0">
+          <div
+            className="max-h-[60vh] space-y-4 overflow-y-auto p-4"
+            aria-live="polite"
+            aria-label="Conversation thread"
+            data-testid="conversation-thread"
+          >
+            {events.length === 0 ? (
+              <p className="text-sm text-muted-foreground">
+                No events on this thread yet.
+              </p>
+            ) : (
+              events.map((event) => (
+                <ConversationEventRow key={event.id} event={event} />
+              ))
+            )}
+            <div ref={bottomRef} />
+          </div>
+
+          <ConversationComposer
+            conversationId={id}
+            defaultRecipient={defaultRecipient}
+            participants={summary.participants ?? []}
+          />
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/Cvoya.Spring.Web/src/app/conversations/[id]/page.tsx
+++ b/src/Cvoya.Spring.Web/src/app/conversations/[id]/page.tsx
@@ -1,0 +1,10 @@
+import { ConversationDetailClient } from "./conversation-detail-client";
+
+interface PageProps {
+  params: Promise<{ id: string }>;
+}
+
+export default async function ConversationDetailPage({ params }: PageProps) {
+  const { id } = await params;
+  return <ConversationDetailClient id={decodeURIComponent(id)} />;
+}

--- a/src/Cvoya.Spring.Web/src/app/conversations/conversations-page.test.tsx
+++ b/src/Cvoya.Spring.Web/src/app/conversations/conversations-page.test.tsx
@@ -1,0 +1,148 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import type { ReactNode } from "react";
+
+import ConversationsPage from "./page";
+
+const mockListConversations = vi.fn();
+const mockListInbox = vi.fn();
+
+vi.mock("@/lib/api/client", () => ({
+  api: {
+    listConversations: (...args: unknown[]) => mockListConversations(...args),
+    listInbox: (...args: unknown[]) => mockListInbox(...args),
+  },
+}));
+
+vi.mock("@/lib/stream/use-activity-stream", () => ({
+  useActivityStream: () => ({ events: [], connected: false }),
+}));
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ replace: vi.fn(), push: vi.fn() }),
+  useSearchParams: () => new URLSearchParams(""),
+}));
+
+vi.mock("next/link", () => ({
+  default: ({
+    href,
+    children,
+    ...rest
+  }: {
+    href: string;
+    children: React.ReactNode;
+  } & Record<string, unknown>) => (
+    <a href={href} {...rest}>
+      {children}
+    </a>
+  ),
+}));
+
+function Wrapper({ children }: { children: ReactNode }) {
+  const client = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, gcTime: 0, staleTime: 0 },
+    },
+  });
+  return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+}
+
+const conversations = [
+  {
+    id: "conv-1",
+    participants: ["human://savas", "agent://ada"],
+    status: "active",
+    lastActivity: new Date().toISOString(),
+    createdAt: new Date().toISOString(),
+    eventCount: 4,
+    origin: "human://savas",
+    summary: "Help me debug the auth flow",
+  },
+  {
+    id: "conv-2",
+    participants: ["unit://eng"],
+    status: "completed",
+    lastActivity: new Date().toISOString(),
+    createdAt: new Date().toISOString(),
+    eventCount: 12,
+    origin: "unit://eng",
+    summary: "Standup",
+  },
+];
+
+describe("ConversationsPage", () => {
+  beforeEach(() => {
+    mockListConversations.mockReset();
+    mockListInbox.mockReset();
+    mockListConversations.mockResolvedValue(conversations);
+    mockListInbox.mockResolvedValue([]);
+  });
+
+  it("renders the conversation list from the API", async () => {
+    render(
+      <Wrapper>
+        <ConversationsPage />
+      </Wrapper>,
+    );
+    await waitFor(() => {
+      expect(
+        screen.getByTestId("conversation-card-conv-1"),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByTestId("conversation-card-conv-2"),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("shows the empty inbox message when there are no asks", async () => {
+    render(
+      <Wrapper>
+        <ConversationsPage />
+      </Wrapper>,
+    );
+    await waitFor(() => {
+      expect(
+        screen.getByText("No conversations are waiting on you."),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("renders inbox items as links to the corresponding conversation", async () => {
+    mockListInbox.mockResolvedValue([
+      {
+        conversationId: "conv-7",
+        from: "agent://ada",
+        human: "human://savas",
+        pendingSince: new Date().toISOString(),
+        summary: "Need your call on this design choice",
+      },
+    ]);
+    render(
+      <Wrapper>
+        <ConversationsPage />
+      </Wrapper>,
+    );
+    await waitFor(() => {
+      const link = screen.getByText("Need your call on this design choice");
+      expect(link.closest("a")).toHaveAttribute(
+        "href",
+        "/conversations/conv-7",
+      );
+    });
+  });
+
+  it("shows an empty state when the conversation list is empty", async () => {
+    mockListConversations.mockResolvedValue([]);
+    render(
+      <Wrapper>
+        <ConversationsPage />
+      </Wrapper>,
+    );
+    await waitFor(() => {
+      expect(
+        screen.getByText("No conversations match these filters."),
+      ).toBeInTheDocument();
+    });
+  });
+});

--- a/src/Cvoya.Spring.Web/src/app/conversations/page.tsx
+++ b/src/Cvoya.Spring.Web/src/app/conversations/page.tsx
@@ -1,0 +1,286 @@
+"use client";
+
+import { Suspense, useMemo } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+import { Inbox, MessagesSquare, RefreshCw } from "lucide-react";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Skeleton } from "@/components/ui/skeleton";
+import { ConversationCard } from "@/components/cards/conversation-card";
+import { useConversations, useInbox } from "@/lib/api/queries";
+import { useActivityStream } from "@/lib/stream/use-activity-stream";
+import type { ConversationListFilters } from "@/lib/api/types";
+import { timeAgo } from "@/lib/utils";
+import Link from "next/link";
+
+const STATUSES: Array<{ value: "" | "active" | "completed"; label: string }> = [
+  { value: "", label: "All" },
+  { value: "active", label: "Active" },
+  { value: "completed", label: "Completed" },
+];
+
+function setOrDelete(
+  params: URLSearchParams,
+  key: string,
+  value: string | null,
+) {
+  if (value === null || value === "") {
+    params.delete(key);
+  } else {
+    params.set(key, value);
+  }
+}
+
+function ConversationsListContent() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+
+  // The filter shape mirrors the CLI's `spring conversation list`
+  // options (#452) so a URL is round-trippable with the CLI mental
+  // model: ?unit=alpha&agent=ada&status=active&participant=human://savas.
+  const filters = useMemo<ConversationListFilters>(() => {
+    const status = searchParams.get("status");
+    return {
+      unit: searchParams.get("unit") ?? undefined,
+      agent: searchParams.get("agent") ?? undefined,
+      participant: searchParams.get("participant") ?? undefined,
+      status:
+        status === "active" || status === "completed" ? status : undefined,
+    };
+  }, [searchParams]);
+
+  const conversationsQuery = useConversations(filters);
+  const inboxQuery = useInbox();
+
+  // Live updates: the activity stream invalidates the conversation
+  // cache slices we care about (see `queryKeysAffectedBySource`), so
+  // we just need the stream open. We pass no filter so unit-, agent-,
+  // and human-scoped events all bubble through.
+  useActivityStream();
+
+  const conversations = conversationsQuery.data ?? [];
+  const inbox = inboxQuery.data ?? [];
+  const loading = conversationsQuery.isPending;
+  const errorMessage =
+    conversationsQuery.error instanceof Error
+      ? conversationsQuery.error.message
+      : null;
+
+  const updateFilter = (key: keyof ConversationListFilters, value: string) => {
+    const params = new URLSearchParams(searchParams.toString());
+    setOrDelete(params, key, value || null);
+    const qs = params.toString();
+    router.replace(qs ? `/conversations?${qs}` : "/conversations");
+  };
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-bold flex items-center gap-2">
+            <MessagesSquare className="h-5 w-5" /> Conversations
+          </h1>
+          <p className="text-sm text-muted-foreground">
+            Message threads between humans, agents, and units. Mirrors{" "}
+            <code className="rounded bg-muted px-1 py-0.5 text-xs">
+              spring conversation list
+            </code>
+            .
+          </p>
+        </div>
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={() => conversationsQuery.refetch()}
+          disabled={conversationsQuery.isFetching}
+        >
+          <RefreshCw
+            className={`h-4 w-4 mr-1 ${
+              conversationsQuery.isFetching ? "animate-spin" : ""
+            }`}
+          />
+          Refresh
+        </Button>
+      </div>
+
+      {/* Inbox — conversations awaiting the current human caller. */}
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            <Inbox className="h-4 w-4" /> Awaiting you
+            {inbox.length > 0 && (
+              <Badge variant="warning" className="ml-1">
+                {inbox.length}
+              </Badge>
+            )}
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          {inboxQuery.isPending ? (
+            <Skeleton className="h-12" />
+          ) : inbox.length === 0 ? (
+            <p className="text-sm text-muted-foreground">
+              No conversations are waiting on you.
+            </p>
+          ) : (
+            <ul
+              className="divide-y divide-border text-sm"
+              aria-label="Inbox"
+            >
+              {inbox.map((item) => (
+                <li
+                  key={item.conversationId}
+                  className="flex items-center gap-3 py-2"
+                >
+                  <Badge variant="outline" className="shrink-0">
+                    {item.from}
+                  </Badge>
+                  <Link
+                    href={`/conversations/${encodeURIComponent(item.conversationId)}`}
+                    className="min-w-0 flex-1 truncate hover:underline"
+                  >
+                    {item.summary || item.conversationId}
+                  </Link>
+                  <span className="shrink-0 text-xs text-muted-foreground">
+                    {timeAgo(item.pendingSince)}
+                  </span>
+                </li>
+              ))}
+            </ul>
+          )}
+        </CardContent>
+      </Card>
+
+      {/* Filters */}
+      <Card>
+        <CardContent className="pt-4">
+          <div className="flex flex-wrap gap-3">
+            <label className="space-y-1">
+              <span className="text-xs text-muted-foreground">Unit</span>
+              <Input
+                placeholder="e.g. engineering-team"
+                defaultValue={filters.unit ?? ""}
+                onBlur={(e) => updateFilter("unit", e.target.value.trim())}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter") {
+                    e.preventDefault();
+                    updateFilter("unit", e.currentTarget.value.trim());
+                  }
+                }}
+                className="w-44"
+              />
+            </label>
+            <label className="space-y-1">
+              <span className="text-xs text-muted-foreground">Agent</span>
+              <Input
+                placeholder="e.g. ada"
+                defaultValue={filters.agent ?? ""}
+                onBlur={(e) => updateFilter("agent", e.target.value.trim())}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter") {
+                    e.preventDefault();
+                    updateFilter("agent", e.currentTarget.value.trim());
+                  }
+                }}
+                className="w-44"
+              />
+            </label>
+            <label className="space-y-1">
+              <span className="text-xs text-muted-foreground">Participant</span>
+              <Input
+                placeholder="scheme://path"
+                defaultValue={filters.participant ?? ""}
+                onBlur={(e) =>
+                  updateFilter("participant", e.target.value.trim())
+                }
+                onKeyDown={(e) => {
+                  if (e.key === "Enter") {
+                    e.preventDefault();
+                    updateFilter(
+                      "participant",
+                      e.currentTarget.value.trim(),
+                    );
+                  }
+                }}
+                className="w-56"
+              />
+            </label>
+            <label className="space-y-1">
+              <span className="text-xs text-muted-foreground">Status</span>
+              <select
+                value={filters.status ?? ""}
+                onChange={(e) => updateFilter("status", e.target.value)}
+                className="flex h-9 w-36 rounded-md border border-input bg-background px-3 py-1 text-sm shadow-sm focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+              >
+                {STATUSES.map((s) => (
+                  <option key={s.value} value={s.value}>
+                    {s.label}
+                  </option>
+                ))}
+              </select>
+            </label>
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* Conversation grid */}
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            <MessagesSquare className="h-4 w-4" />
+            All conversations
+            {conversationsQuery.data && (
+              <span className="ml-auto text-sm font-normal text-muted-foreground">
+                {conversations.length} shown
+              </span>
+            )}
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          {errorMessage && (
+            <p className="rounded-md border border-destructive/50 bg-destructive/10 px-3 py-2 text-sm text-destructive mb-3">
+              {errorMessage}
+            </p>
+          )}
+          {loading ? (
+            <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
+              <Skeleton className="h-32" />
+              <Skeleton className="h-32" />
+              <Skeleton className="h-32" />
+            </div>
+          ) : conversations.length === 0 ? (
+            <p className="text-sm text-muted-foreground">
+              No conversations match these filters.
+            </p>
+          ) : (
+            <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
+              {conversations.map((c) => (
+                <ConversationCard
+                  key={c.id}
+                  conversation={{
+                    id: c.id,
+                    title: c.summary,
+                    participants: c.participants,
+                    lastActivityAt: c.lastActivity,
+                    status: c.status,
+                  }}
+                />
+              ))}
+            </div>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}
+
+export default function ConversationsPage() {
+  return (
+    <Suspense fallback={<Skeleton className="h-40" />}>
+      <ConversationsListContent />
+    </Suspense>
+  );
+}

--- a/src/Cvoya.Spring.Web/src/app/units/[id]/unit-config-client.tsx
+++ b/src/Cvoya.Spring.Web/src/app/units/[id]/unit-config-client.tsx
@@ -2,8 +2,10 @@
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
+import Link from "next/link";
 import {
   DollarSign,
+  MessagesSquare,
   Play,
   Settings,
   Square,
@@ -324,6 +326,25 @@ export default function UnitConfigClient({ id }: ClientProps) {
           {actionError}
         </p>
       )}
+
+      {/* Quick link to the conversation surface filtered to this
+          unit (#410). Mirrors `spring conversation list --unit <name>`
+          so the portal exposes the same one-click jump. */}
+      <Card>
+        <CardContent className="flex items-center justify-between gap-3 py-4 text-sm">
+          <div className="flex items-center gap-2">
+            <MessagesSquare className="h-4 w-4 text-muted-foreground" />
+            <span>Conversations involving this unit</span>
+          </div>
+          <Link
+            href={`/conversations?unit=${encodeURIComponent(unit.name)}`}
+            className="inline-flex items-center gap-1 rounded-md border border-input bg-background px-3 py-1 text-xs font-medium text-primary hover:bg-accent"
+            data-testid="unit-conversations-link"
+          >
+            View threads →
+          </Link>
+        </CardContent>
+      </Card>
 
       <Tabs defaultValue="general">
         <TabsList>

--- a/src/Cvoya.Spring.Web/src/components/conversation/conversation-composer.tsx
+++ b/src/Cvoya.Spring.Web/src/components/conversation/conversation-composer.tsx
@@ -1,0 +1,173 @@
+"use client";
+
+import { useState } from "react";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { Send } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { useToast } from "@/components/ui/toast";
+import { api } from "@/lib/api/client";
+import { queryKeys } from "@/lib/api/query-keys";
+import { parseConversationSource } from "./role";
+
+interface ConversationComposerProps {
+  conversationId: string;
+  /**
+   * Default `scheme://path` recipient pre-selected in the picker. The
+   * detail page picks the most-recently-active non-self participant so
+   * the common case (replying to the last speaker) is one keystroke.
+   */
+  defaultRecipient?: string;
+  /**
+   * Other addresses observed on the thread. Rendered as quick-pick
+   * pills above the textarea so the user can re-target without typing.
+   */
+  participants?: string[];
+}
+
+/**
+ * Message composer for a conversation thread.
+ *
+ * The composer is intentionally CLI-shaped: it asks for an `address`
+ * and a `text`, the same two arguments `spring conversation send`
+ * takes (#452). The form does NOT carry a "from" — the platform infers
+ * the sender from the authenticated context, exactly like the CLI.
+ *
+ * Live updates flow through the activity stream — the SSE handler
+ * invalidates `queryKeys.conversations.detail(id)` (see
+ * `queryKeysAffectedBySource` for the unit/agent/conversation/human
+ * scheme cases), so the new message renders without a manual refetch.
+ * We still invalidate explicitly on success as a belt-and-braces
+ * fallback for environments where SSE is proxied/disabled.
+ */
+export function ConversationComposer({
+  conversationId,
+  defaultRecipient,
+  participants = [],
+}: ConversationComposerProps) {
+  const { toast } = useToast();
+  const queryClient = useQueryClient();
+  // The recipient is seeded once from the default — re-syncing on
+  // every render would clobber a user-edited value when the thread
+  // refreshes. Users can use the participant pills below to retarget.
+  const [recipient, setRecipient] = useState(defaultRecipient ?? "");
+  const [text, setText] = useState("");
+
+  const send = useMutation({
+    mutationFn: async () => {
+      const trimmed = text.trim();
+      const target = recipient.trim();
+      if (!trimmed) {
+        throw new Error("Message text is required.");
+      }
+      if (!target) {
+        throw new Error("Recipient address is required.");
+      }
+      const { scheme, path } = parseConversationSource(target);
+      if (!scheme || !path) {
+        throw new Error(
+          "Recipient must be in scheme://path form (e.g. agent://ada).",
+        );
+      }
+      return api.sendConversationMessage(conversationId, {
+        to: { scheme, path },
+        text: trimmed,
+      });
+    },
+    onSuccess: () => {
+      setText("");
+      // Belt-and-braces invalidation; the activity stream usually
+      // beats us to it but proxies / dev tunnels can drop SSE.
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.conversations.detail(conversationId),
+      });
+      queryClient.invalidateQueries({ queryKey: queryKeys.conversations.all });
+      queryClient.invalidateQueries({ queryKey: queryKeys.activity.all });
+    },
+    onError: (err) => {
+      toast({
+        title: "Failed to send message",
+        description: err instanceof Error ? err.message : String(err),
+        variant: "destructive",
+      });
+    },
+  });
+
+  const submit = () => {
+    if (send.isPending) return;
+    send.mutate();
+  };
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    submit();
+  };
+
+  // Cmd/Ctrl+Enter sends — matches the textbook chat ergonomic and
+  // mirrors the CLI's "type then ENTER" affordance for one-line text.
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    if ((e.metaKey || e.ctrlKey) && e.key === "Enter") {
+      e.preventDefault();
+      submit();
+    }
+  };
+
+  return (
+    <form
+      onSubmit={handleSubmit}
+      className="space-y-2 border-t border-border bg-muted/20 p-3"
+      aria-label="Reply to conversation"
+    >
+      {participants.length > 0 && (
+        <div className="flex flex-wrap items-center gap-1 text-xs">
+          <span className="text-muted-foreground">To:</span>
+          {participants.map((p) => (
+            <button
+              key={p}
+              type="button"
+              onClick={() => setRecipient(p)}
+              className={
+                recipient === p
+                  ? "rounded border border-primary bg-primary/10 px-2 py-0.5 font-mono text-[11px]"
+                  : "rounded border border-input bg-background px-2 py-0.5 font-mono text-[11px] hover:bg-muted"
+              }
+              aria-pressed={recipient === p}
+            >
+              {p}
+            </button>
+          ))}
+        </div>
+      )}
+      <input
+        type="text"
+        value={recipient}
+        onChange={(e) => setRecipient(e.target.value)}
+        placeholder="Recipient (scheme://path, e.g. agent://ada)"
+        className="flex h-9 w-full rounded-md border border-input bg-background px-3 py-1 font-mono text-xs shadow-sm focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+        aria-label="Recipient address"
+      />
+      <textarea
+        value={text}
+        onChange={(e) => setText(e.target.value)}
+        onKeyDown={handleKeyDown}
+        placeholder="Type a message…  (⌘/Ctrl+Enter to send)"
+        rows={3}
+        className="flex w-full rounded-md border border-input bg-background px-3 py-2 text-sm shadow-sm focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring resize-y min-h-[60px]"
+        aria-label="Message text"
+      />
+      <div className="flex items-center justify-end gap-2">
+        <span className="text-xs text-muted-foreground">
+          {send.isPending ? "Sending…" : "⌘/Ctrl+Enter to send"}
+        </span>
+        <Button
+          type="submit"
+          size="sm"
+          disabled={send.isPending || !text.trim() || !recipient.trim()}
+        >
+          <Send className="mr-1 h-4 w-4" />
+          Send
+        </Button>
+      </div>
+    </form>
+  );
+}

--- a/src/Cvoya.Spring.Web/src/components/conversation/conversation-event-row.tsx
+++ b/src/Cvoya.Spring.Web/src/components/conversation/conversation-event-row.tsx
@@ -1,0 +1,136 @@
+"use client";
+
+import { useState } from "react";
+import { ChevronDown, ChevronRight, Wrench } from "lucide-react";
+import Link from "next/link";
+
+import { Badge } from "@/components/ui/badge";
+import { cn } from "@/lib/utils";
+import type { ConversationEvent } from "@/lib/api/types";
+import {
+  parseConversationSource,
+  ROLE_STYLES,
+  roleFromEvent,
+  type ConversationRole,
+} from "./role";
+
+/**
+ * Whether this event type should render as a collapsed call-out by
+ * default. Tool calls (`DecisionMade`) and lifecycle events
+ * (`StateChanged`, `WorkflowStepCompleted`) start collapsed; messages
+ * stay expanded so the thread reads like a chat.
+ */
+function isCollapsibleByDefault(eventType: string, role: ConversationRole) {
+  if (role === "tool") return true;
+  return (
+    eventType === "StateChanged" ||
+    eventType === "WorkflowStepCompleted" ||
+    eventType === "ReflectionCompleted"
+  );
+}
+
+interface ConversationEventRowProps {
+  event: ConversationEvent;
+}
+
+export function ConversationEventRow({ event }: ConversationEventRowProps) {
+  const role = roleFromEvent(event.source, event.eventType);
+  const style = ROLE_STYLES[role];
+  const source = parseConversationSource(event.source);
+  const collapsible = isCollapsibleByDefault(event.eventType, role);
+  const [expanded, setExpanded] = useState(!collapsible);
+
+  const timestamp = new Date(event.timestamp);
+
+  return (
+    <div
+      className={cn(
+        "flex w-full",
+        style.align === "end" ? "justify-end" : "justify-start",
+      )}
+      data-testid={`conversation-event-${event.id}`}
+      data-role={role}
+    >
+      <div className={cn("flex max-w-[80%] flex-col gap-1", "min-w-0")}>
+        <div
+          className={cn(
+            "flex items-center gap-2 text-xs text-muted-foreground",
+            style.align === "end" ? "justify-end" : "justify-start",
+          )}
+        >
+          <Badge variant="outline" className="h-5 px-1.5 text-[10px]">
+            {style.label}
+          </Badge>
+          <span className="truncate font-mono">{source.raw}</span>
+          <span aria-hidden="true">·</span>
+          <time
+            dateTime={event.timestamp}
+            title={timestamp.toLocaleString()}
+          >
+            {timestamp.toLocaleTimeString([], {
+              hour: "2-digit",
+              minute: "2-digit",
+            })}
+          </time>
+        </div>
+
+        <div
+          className={cn(
+            "rounded-lg px-3 py-2 text-sm shadow-sm",
+            style.bubble,
+          )}
+        >
+          {collapsible ? (
+            <button
+              type="button"
+              onClick={() => setExpanded((v) => !v)}
+              className="flex w-full items-center gap-2 text-left"
+              aria-expanded={expanded}
+            >
+              {expanded ? (
+                <ChevronDown className="h-3.5 w-3.5 shrink-0" />
+              ) : (
+                <ChevronRight className="h-3.5 w-3.5 shrink-0" />
+              )}
+              {role === "tool" && (
+                <Wrench className="h-3.5 w-3.5 shrink-0" aria-hidden="true" />
+              )}
+              <span className="min-w-0 flex-1 truncate">
+                {role === "tool" ? "Tool call" : event.eventType}
+                {event.summary ? ` — ${event.summary}` : ""}
+              </span>
+            </button>
+          ) : (
+            <p className="whitespace-pre-wrap break-words">{event.summary}</p>
+          )}
+
+          {expanded && collapsible && (
+            <div className="mt-2 space-y-1 rounded border border-black/5 bg-background/40 p-2 text-xs">
+              <p className="whitespace-pre-wrap break-words">
+                {event.summary}
+              </p>
+              <p className="text-muted-foreground">
+                {event.eventType} · {event.severity}
+              </p>
+            </div>
+          )}
+        </div>
+
+        <div
+          className={cn(
+            "flex items-center gap-2 text-[11px] text-muted-foreground",
+            style.align === "end" ? "justify-end" : "justify-start",
+          )}
+        >
+          <Link
+            href={`/activity?source=${encodeURIComponent(source.raw)}`}
+            className="hover:underline"
+            aria-label="Open in activity log"
+          >
+            View in activity →
+          </Link>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/Cvoya.Spring.Web/src/components/conversation/role.test.ts
+++ b/src/Cvoya.Spring.Web/src/components/conversation/role.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  parseConversationSource,
+  ROLE_STYLES,
+  roleFromEvent,
+} from "./role";
+
+describe("parseConversationSource", () => {
+  it("splits scheme and path", () => {
+    expect(parseConversationSource("agent://ada")).toEqual({
+      scheme: "agent",
+      path: "ada",
+      raw: "agent://ada",
+    });
+  });
+
+  it("preserves nested paths", () => {
+    expect(parseConversationSource("agent://team/ada")).toEqual({
+      scheme: "agent",
+      path: "team/ada",
+      raw: "agent://team/ada",
+    });
+  });
+
+  it("falls back to system scheme when no separator is present", () => {
+    expect(parseConversationSource("scheduler")).toEqual({
+      scheme: "system",
+      path: "scheduler",
+      raw: "scheduler",
+    });
+  });
+
+  it("lowercases the scheme", () => {
+    expect(parseConversationSource("HUMAN://savas")).toEqual({
+      scheme: "human",
+      path: "savas",
+      raw: "HUMAN://savas",
+    });
+  });
+});
+
+describe("roleFromEvent", () => {
+  it("maps scheme to role for message events", () => {
+    expect(roleFromEvent("human://savas", "MessageReceived")).toBe("human");
+    expect(roleFromEvent("agent://ada", "MessageSent")).toBe("agent");
+    expect(roleFromEvent("unit://eng", "ConversationStarted")).toBe("unit");
+  });
+
+  it("treats DecisionMade as a tool call regardless of source", () => {
+    expect(roleFromEvent("agent://ada", "DecisionMade")).toBe("tool");
+    expect(roleFromEvent("unit://eng", "DecisionMade")).toBe("tool");
+  });
+
+  it("falls back to system for unknown schemes", () => {
+    expect(roleFromEvent("scheduler", "StateChanged")).toBe("system");
+    expect(roleFromEvent("foo://bar", "StateChanged")).toBe("system");
+  });
+});
+
+describe("ROLE_STYLES", () => {
+  it("right-aligns human bubbles and left-aligns the rest", () => {
+    expect(ROLE_STYLES.human.align).toBe("end");
+    expect(ROLE_STYLES.agent.align).toBe("start");
+    expect(ROLE_STYLES.unit.align).toBe("start");
+    expect(ROLE_STYLES.tool.align).toBe("start");
+    expect(ROLE_STYLES.system.align).toBe("start");
+  });
+});

--- a/src/Cvoya.Spring.Web/src/components/conversation/role.ts
+++ b/src/Cvoya.Spring.Web/src/components/conversation/role.ts
@@ -1,0 +1,95 @@
+/**
+ * Role attribution helpers for the conversation thread UI (#410).
+ *
+ * Conversations are derived from the activity event stream. Each event
+ * carries a `source` address shaped as `scheme://path` (the platform
+ * persists the message envelope as activity events; see
+ * `docs/architecture/messaging.md`). The UI maps the scheme to a small
+ * fixed set of presentation roles so visually distinct bubbles stay
+ * consistent across the portal.
+ */
+
+export type ConversationRole = "human" | "agent" | "unit" | "tool" | "system";
+
+export interface ParsedConversationSource {
+  scheme: string;
+  path: string;
+  /** Original `scheme://path` source string. */
+  raw: string;
+}
+
+/**
+ * Splits a `scheme://path` source into its components. Falls back to a
+ * `system://<raw>` shape when the value doesn't contain a `://`
+ * separator — the projection layer can emit shorthand on
+ * platform-internal events.
+ */
+export function parseConversationSource(
+  source: string,
+): ParsedConversationSource {
+  const idx = source.indexOf("://");
+  if (idx <= 0) {
+    return { scheme: "system", path: source, raw: source };
+  }
+  return {
+    scheme: source.slice(0, idx).toLowerCase(),
+    path: source.slice(idx + 3),
+    raw: source,
+  };
+}
+
+/**
+ * Resolves the presentation role for a thread event. Tool-call events
+ * (`DecisionMade`) get their own role so the thread view can render
+ * them as collapsed call-outs (#410 § role attribution).
+ */
+export function roleFromEvent(
+  source: string,
+  eventType: string,
+): ConversationRole {
+  if (eventType === "DecisionMade") {
+    return "tool";
+  }
+  const { scheme } = parseConversationSource(source);
+  if (scheme === "human") return "human";
+  if (scheme === "agent") return "agent";
+  if (scheme === "unit") return "unit";
+  return "system";
+}
+
+export interface RoleStyle {
+  /** Container alignment for the role bubble. */
+  align: "start" | "end";
+  /** Tailwind classes applied to the bubble container. */
+  bubble: string;
+  /** Short human-readable label for the role pill. */
+  label: string;
+}
+
+export const ROLE_STYLES: Record<ConversationRole, RoleStyle> = {
+  human: {
+    align: "end",
+    bubble: "bg-primary text-primary-foreground",
+    label: "Human",
+  },
+  agent: {
+    align: "start",
+    bubble: "bg-muted text-foreground",
+    label: "Agent",
+  },
+  unit: {
+    align: "start",
+    bubble: "bg-muted/60 text-foreground",
+    label: "Unit",
+  },
+  tool: {
+    align: "start",
+    bubble: "bg-amber-50 text-amber-900 border border-amber-200",
+    label: "Tool",
+  },
+  system: {
+    align: "start",
+    bubble: "bg-muted/40 text-muted-foreground italic",
+    label: "System",
+  },
+};

--- a/src/Cvoya.Spring.Web/src/lib/api/client.ts
+++ b/src/Cvoya.Spring.Web/src/lib/api/client.ts
@@ -3,6 +3,8 @@ import createClient from "openapi-fetch";
 import type { paths } from "./schema";
 import type {
   AgentDetailResponse,
+  ConversationListFilters,
+  ConversationMessageRequest,
   CreateCloneRequest,
   CreateSecretRequest,
   CreateUnitFromTemplateRequest,
@@ -432,6 +434,49 @@ export const api = {
         params: { query: params as never },
       }),
     ),
+
+  // Conversations (#410)
+  //
+  // Conversations are a projection over the activity event stream;
+  // these endpoints are the typed surface the CLI's `spring conversation
+  // {list,show,send}` commands use, and the portal mirrors that 1:1 per
+  // CONVENTIONS.md § ui-cli-parity.
+  listConversations: async (filters?: ConversationListFilters) => {
+    // The OpenAPI binder uses TitleCase property names (Unit, Agent,
+    // Status, Participant, Limit) for [AsParameters] queries. Translate
+    // the camelCase shape we expose to call sites.
+    const query: Record<string, string | number> = {};
+    if (filters?.unit) query.Unit = filters.unit;
+    if (filters?.agent) query.Agent = filters.agent;
+    if (filters?.status) query.Status = filters.status;
+    if (filters?.participant) query.Participant = filters.participant;
+    if (filters?.limit !== undefined) query.Limit = filters.limit;
+    return unwrap(
+      await fetchClient.GET("/api/v1/conversations", {
+        params: { query: query as never },
+      }),
+    );
+  },
+  getConversation: async (id: string) => {
+    const result = await fetchClient.GET("/api/v1/conversations/{id}", {
+      params: { path: { id } },
+    });
+    if (result.response.status === 404) {
+      return null;
+    }
+    return unwrap(result);
+  },
+  sendConversationMessage: async (
+    id: string,
+    body: ConversationMessageRequest,
+  ) =>
+    unwrap(
+      await fetchClient.POST("/api/v1/conversations/{id}/messages", {
+        params: { path: { id } },
+        body,
+      }),
+    ),
+  listInbox: async () => unwrap(await fetchClient.GET("/api/v1/inbox")),
 
   // Initiative
   getAgentInitiativePolicy: async (id: string) =>

--- a/src/Cvoya.Spring.Web/src/lib/api/queries.ts
+++ b/src/Cvoya.Spring.Web/src/lib/api/queries.ts
@@ -27,9 +27,13 @@ import type {
   BudgetResponse,
   CloneResponse,
   ConnectorTypeResponse,
+  ConversationDetail,
+  ConversationListFilters,
+  ConversationSummary,
   CostDashboardSummary,
   CostSummaryResponse,
   DashboardSummary,
+  InboxItem,
   InitiativeLevelResponse,
   InitiativePolicy,
   PackageDetail,
@@ -290,6 +294,51 @@ export function useActivityQuery(
     queryKey: queryKeys.activity.query(params),
     queryFn: async () =>
       (await api.queryActivity(params)) as ActivityQueryResult,
+    ...opts,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Conversations (#410)
+// ---------------------------------------------------------------------------
+//
+// The list endpoint accepts a small set of filter knobs; we serialize
+// them into the query key as-is so two pages with different filters
+// don't collide. Detail keeps its own per-id slice so the live SSE
+// stream can patch a single thread without touching unrelated rows.
+
+export function useConversations(
+  filters?: ConversationListFilters,
+  opts?: SliceOptions<ConversationSummary[]>,
+): UseQueryResult<ConversationSummary[], Error> {
+  return useQuery({
+    queryKey: queryKeys.conversations.list(
+      filters as Record<string, unknown> | undefined,
+    ),
+    queryFn: () => api.listConversations(filters),
+    ...opts,
+  });
+}
+
+export function useConversation(
+  id: string,
+  opts?: SliceOptions<ConversationDetail | null>,
+): UseQueryResult<ConversationDetail | null, Error> {
+  return useQuery({
+    queryKey: queryKeys.conversations.detail(id),
+    queryFn: () => api.getConversation(id),
+    enabled: opts?.enabled ?? Boolean(id),
+    refetchInterval: opts?.refetchInterval,
+    staleTime: opts?.staleTime,
+  });
+}
+
+export function useInbox(
+  opts?: SliceOptions<InboxItem[]>,
+): UseQueryResult<InboxItem[], Error> {
+  return useQuery({
+    queryKey: queryKeys.conversations.inbox(),
+    queryFn: () => api.listInbox(),
     ...opts,
   });
 }

--- a/src/Cvoya.Spring.Web/src/lib/api/query-keys.ts
+++ b/src/Cvoya.Spring.Web/src/lib/api/query-keys.ts
@@ -59,6 +59,14 @@ export const queryKeys = {
       ["activity", "query", params ?? {}] as const,
   },
 
+  conversations: {
+    all: ["conversations"] as const,
+    list: (filters?: Record<string, unknown>) =>
+      ["conversations", "list", filters ?? {}] as const,
+    detail: (id: string) => ["conversations", "detail", id] as const,
+    inbox: () => ["conversations", "inbox"] as const,
+  },
+
   tenant: {
     budget: () => ["tenant", "budget"] as const,
   },
@@ -113,6 +121,7 @@ export function queryKeysAffectedBySource(source: {
       queryKeys.dashboard.all,
       queryKeys.units.detail(source.path),
       queryKeys.units.cost(source.path),
+      queryKeys.conversations.all,
     ];
   }
   if (scheme === "agent") {
@@ -121,7 +130,27 @@ export function queryKeysAffectedBySource(source: {
       queryKeys.dashboard.all,
       queryKeys.agents.detail(source.path),
       queryKeys.agents.cost(source.path),
+      queryKeys.conversations.all,
     ];
   }
-  return [queryKeys.activity.all, queryKeys.dashboard.all];
+  if (scheme === "conversation") {
+    return [
+      queryKeys.activity.all,
+      queryKeys.conversations.all,
+      queryKeys.conversations.detail(source.path),
+    ];
+  }
+  if (scheme === "human") {
+    return [
+      queryKeys.activity.all,
+      queryKeys.dashboard.all,
+      queryKeys.conversations.all,
+      queryKeys.conversations.inbox(),
+    ];
+  }
+  return [
+    queryKeys.activity.all,
+    queryKeys.dashboard.all,
+    queryKeys.conversations.all,
+  ];
 }

--- a/src/Cvoya.Spring.Web/src/lib/api/types.ts
+++ b/src/Cvoya.Spring.Web/src/lib/api/types.ts
@@ -110,6 +110,37 @@ export type SetBudgetRequest = Schemas["SetBudgetRequest"];
 /** GET /api/v1/activity query response. */
 export type ActivityQueryResult = Schemas["ActivityQueryResult"];
 
+// ---------------------------------------------------------------------------
+// Conversations & inbox (#410, #452, #456)
+// ---------------------------------------------------------------------------
+
+/** Row in the conversation list (`GET /api/v1/conversations`). */
+export type ConversationSummary = Schemas["ConversationSummary"];
+
+/** Conversation thread payload (`GET /api/v1/conversations/{id}`). */
+export type ConversationDetail = Schemas["ConversationDetail"];
+
+/** One event on a conversation thread. */
+export type ConversationEvent = Schemas["ConversationEvent"];
+
+/** Request body for `POST /api/v1/conversations/{id}/messages`. */
+export type ConversationMessageRequest = Schemas["ConversationMessageRequest"];
+
+/** Response body for `POST /api/v1/conversations/{id}/messages`. */
+export type ConversationMessageResponse = Schemas["ConversationMessageResponse"];
+
+/** Row in the awaiting-me queue (`GET /api/v1/inbox`). */
+export type InboxItem = Schemas["InboxItem"];
+
+/** Query-string filters accepted by `GET /api/v1/conversations`. */
+export interface ConversationListFilters {
+  unit?: string;
+  agent?: string;
+  status?: "active" | "completed";
+  participant?: string;
+  limit?: number;
+}
+
 /** Matches Cvoya.Spring.Core.Initiative.InitiativeLevel enum. */
 export type InitiativeLevel = Schemas["InitiativeLevel"];
 

--- a/src/Cvoya.Spring.Web/src/lib/extensions/defaults.ts
+++ b/src/Cvoya.Spring.Web/src/lib/extensions/defaults.ts
@@ -6,6 +6,7 @@
 import {
   Activity,
   LayoutDashboard,
+  MessagesSquare,
   Network,
   Package,
   Plus,
@@ -65,6 +66,15 @@ export const defaultRoutes: readonly RouteEntry[] = [
     orderHint: 30,
     keywords: ["events", "log", "stream", "audit"],
     description: "Raw activity event stream with filters.",
+  },
+  {
+    path: "/conversations",
+    label: "Conversations",
+    icon: MessagesSquare,
+    navSection: "primary",
+    orderHint: 35,
+    keywords: ["chat", "thread", "message", "spring conversation list"],
+    description: "Message threads between humans, agents, and units.",
   },
   {
     path: "/initiative",
@@ -150,6 +160,16 @@ export const defaultActions: readonly PaletteAction[] = [
     orderHint: 50,
     keywords: ["spring activity stream", "tail", "logs"],
     href: "/activity",
+  },
+  {
+    id: "conversation.list",
+    label: "List conversations",
+    icon: MessagesSquare,
+    section: "actions",
+    orderHint: 55,
+    keywords: ["spring conversation list", "threads", "chat"],
+    description: "Browse message threads between humans, agents, and units.",
+    href: "/conversations",
   },
   {
     id: "budget.view",


### PR DESCRIPTION
## Summary

Bring the existing CLI conversation surface (`spring conversation list/show/send`, `spring inbox list`) into the web portal as the chat-shaped projection over the shared activity event stream — no new persistence, just a new view of the same events. Closes #410.

### New surfaces

- **`/conversations`** — filtered list (`unit`, `agent`, `participant`, `status` query params round-trip with the CLI's `--unit/--agent/--participant/--status` flags), an "Awaiting you" panel backed by `GET /api/v1/inbox`, a `<ConversationCard>` grid, breadcrumbs, and live SSE-driven refresh.
- **`/conversations/[id]`** — full thread with role-attributed bubbles (human right-aligned; agent/unit/system left-aligned with distinct surfaces; `DecisionMade` / lifecycle events render as collapsed tool-call cards), header showing status + participants + an "Origin" deep-link to `/activity?source=…`, and a composer that POSTs `/api/v1/conversations/{id}/messages` (Cmd/Ctrl+Enter to send). Live updates via the activity SSE stream filtered by `correlationId`.
- **Cross-linking** — activity rows that carry a correlation id grow an "Open thread" pill that deep-links to `/conversations/{id}`; agent and unit detail pages get a quick-link card to the filtered list.

### Plumbing

- Typed API client methods (`listConversations`, `getConversation`, `sendConversationMessage`, `listInbox`) on top of the existing `openapi-fetch` setup.
- TanStack Query keys + hooks (`useConversations`, `useConversation`, `useInbox`).
- Conversation cache invalidations wired into the existing `queryKeysAffectedBySource` table so the activity SSE stream drives refreshes everywhere — no polling.
- Sidebar gains a **Conversations** entry via the extension defaults.

### Docs

- `src/Cvoya.Spring.Web/DESIGN.md` — new "7.12 Conversation thread" section + `ConversationCard` listed alongside the other domain-entity cards.
- `docs/architecture/messaging.md` — new "Conversation Surfaces" section explaining the projection model, the CLI/UI parity mapping, and the cross-linking pattern.
- `docs/guide/portal.md` — full Conversations walkthrough (list + thread), updated sidebar table, parity-table refresh.

### Tests

- Unit tests for the role-attribution helpers (`role.test.ts`).
- Page-level tests for the list (inbox, filters, empty state) and the thread (rendering, role attribution, origin linking, send via the composer).
- All 168 web tests + 1652 .NET tests pass; lint clean; `dotnet format --verify-no-changes` clean.

## Test plan

- [x] `npm run lint` (web)
- [x] `npm run test` (web — 168 passed)
- [x] `dotnet build`
- [x] `dotnet test` (1652 passed)
- [x] `dotnet format --verify-no-changes`
- [ ] Manual smoke: visit `/conversations`, filter by unit/agent, open a thread, send a message, confirm SSE-driven refresh and activity↔conversation cross-links.


Made with [Cursor](https://cursor.com)