### PR TITLE
Replace engineering follow-up note with user-facing image help (closes #640)

### DIFF
--- a/src/Cvoya.Spring.Web/src/app/units/[id]/execution-tab.tsx
+++ b/src/Cvoya.Spring.Web/src/app/units/[id]/execution-tab.tsx
@@ -231,7 +231,7 @@ export function ExecutionTab({ unitId }: ExecutionTabProps) {
               discovery are tracked follow-ups (#622, #623). */}
           <FieldRow
             label="Image"
-            help="Default container image reference. Autocomplete is tracked as #622."
+            help="Default container image used to launch member agents. Individual agents can override this on their Execution panel."
             onClear={
               persisted?.image ? () => clearField("image") : undefined
             }

--- a/src/Cvoya.Spring.Web/src/app/units/create/page.tsx
+++ b/src/Cvoya.Spring.Web/src/app/units/create/page.tsx
@@ -887,7 +887,9 @@ export default function CreateUnitPage() {
                   aria-label="Execution image"
                 />
                 <span className="block text-xs text-muted-foreground">
-                  Default container image. Autocomplete is tracked as #622.
+                  Default container image used to launch member agents.
+                  Individual agents can override this on their Execution
+                  panel.
                 </span>
               </label>
 


### PR DESCRIPTION
## Summary

- The unit-creation wizard (`src/app/units/create/page.tsx`) and the unit Execution tab (`src/app/units/[id]/execution-tab.tsx`) both rendered the helper text *"Default container image. Autocomplete is tracked as #622."* underneath the image input. That copy exposed an internal tracking reference in the UI, which #640 calls out as inappropriate.
- Replace both strings with one user-facing sentence that explains what the field actually does: it sets the default container image used to launch member agents, and individual agents can override it on their own Execution panel.
- Implementation comments that mention follow-up issues (#622, #623) inside the source are unchanged — only the text shown to operators is updated.

Closes #640.

## Test plan

- [x] `npm run lint` (web workspace) — clean.
- [x] `npx vitest run src/app/units/create/page.test.tsx` — 26/26 pass.
- [ ] Spot-check the wizard and the unit Execution tab in the portal to confirm the new help copy renders under the Image input.


Made with [Cursor](https://cursor.com)