### PR TITLE
Copy public/ into the Web standalone runtime image

### DIFF
--- a/deployment/Dockerfile
+++ b/deployment/Dockerfile
@@ -86,8 +86,16 @@ COPY --from=dotnet-build /publish/cli/    /app/cli/
 # Copy Next.js standalone output. With outputFileTracingRoot pinned to the
 # monorepo root, the standalone tree mirrors the workspace layout — the
 # server entrypoint is at /app/web/src/Cvoya.Spring.Web/server.js.
+#
+# `next build` deliberately omits `public/` from the standalone tree
+# (see https://nextjs.org/docs/app/api-reference/config/next-config-js/output#automatically-copying-traced-files),
+# so without an explicit COPY the brand-mark PNGs under `public/brand/`
+# return 404 in containerized deploys and the sidebar header renders a
+# broken image. Mirror the workspace layout so `server.js` resolves
+# `public/` next to itself, the same way `next start` would.
 COPY --from=web-build /build/src/Cvoya.Spring.Web/.next/standalone /app/web/
 COPY --from=web-build /build/src/Cvoya.Spring.Web/.next/static     /app/web/src/Cvoya.Spring.Web/.next/static
+COPY --from=web-build /build/src/Cvoya.Spring.Web/public           /app/web/src/Cvoya.Spring.Web/public
 
 # Copy Dapr component YAML and Dapr Configuration for both the local and
 # production profiles. Sidecars select a profile via `--resources-path`


### PR DESCRIPTION
## Summary

The dashboard sidebar header rendered a broken-image placeholder (alt text only) where the `BrandMark` sailboat logo should appear in containerized deploys. Root cause: `next build --output=standalone` [does not copy `public/` into the standalone tree](https://nextjs.org/docs/app/api-reference/config/next-config-js/output#automatically-copying-traced-files), and `deployment/Dockerfile` only copied `.next/standalone` and `.next/static`. So `/brand/sailboat-dark.png` (and `-light.png`) returned 404 at runtime even though the assets exist in `src/Cvoya.Spring.Web/public/brand/`.

This PR adds an explicit `COPY` of the `public/` directory into the runtime image, mirroring the workspace layout next to `server.js` — the same arrangement `next start` expects.

`npm run dev` was unaffected (Next dev server serves `public/` directly), which is why this only manifested in the built image.

## Test plan

- [ ] Build the deployment image: `podman build -f deployment/Dockerfile -t spring-voyage:test .`
- [ ] Run the web container and confirm `GET /brand/sailboat-dark.png` returns 200 with `Content-Type: image/png`
- [ ] Open the dashboard and verify the sailboat brand-mark renders in the sidebar header in both `dark` and `light` themes

Made with [Cursor](https://cursor.com)