### PR TITLE
Fix #1042: dispatcher-side workspace prep so claude-code agents can launch

### DIFF
--- a/deployment/deploy.sh
+++ b/deployment/deploy.sh
@@ -281,11 +281,20 @@ start_dispatcher() {
     local socket="${SPRING_DISPATCHER_PODMAN_SOCKET:-/run/podman/podman.sock}"
     local token="${SPRING_DISPATCHER_WORKER_TOKEN:-worker-token}"
     local tenant="${SPRING_DEFAULT_TENANT_ID:-default}"
+    # Per-invocation agent workspace root. The dispatcher writes the
+    # workspace materialised for each agent run here, then bind-mounts
+    # ${workspace_root}/<subdir> into the agent container. Workers no
+    # longer touch the local filesystem (#1042). The named volume is
+    # mounted at the same path so the host's podman can resolve the
+    # bind-mount source.
+    local workspace_root="${SPRING_DISPATCHER_WORKSPACE_ROOT:-/var/lib/spring-workspaces}"
 
     run_container spring-dispatcher \
         --env-file "${RESOLVED_ENV_FILE}" \
         -e "Dispatcher__Tokens__${token}__TenantId=${tenant}" \
+        -e "Dispatcher__WorkspaceRoot=${workspace_root}" \
         -v "${socket}:/run/podman/podman.sock:Z" \
+        -v "spring-agent-workspaces:${workspace_root}" \
         "${SPRING_DISPATCHER_IMAGE:-localhost/spring-dispatcher:latest}" \
         dotnet /app/Cvoya.Spring.Dispatcher.dll
 }

--- a/deployment/docker-compose.yml
+++ b/deployment/docker-compose.yml
@@ -38,6 +38,11 @@ volumes:
   spring-placement-data:
   spring-scheduler-data:
   spring-dataprotection-keys:
+  # Per-invocation agent workspaces materialised by the dispatcher and
+  # bind-mounted into the agent containers podman launches on its behalf
+  # (issue #1042). The dispatcher writes here; the host's podman uses the
+  # same path as the bind-mount source for each agent run.
+  spring-agent-workspaces:
 
 services:
   # -----------------------------------------------------------------
@@ -197,6 +202,11 @@ services:
       # OSS deployment a single shared token is enough; multi-tenant K8s
       # deployments belong in a downstream repo.
       Dispatcher__Tokens__${SPRING_DISPATCHER_WORKER_TOKEN:-worker-token}__TenantId: ${SPRING_DEFAULT_TENANT_ID:-default}
+      # Where the dispatcher writes per-invocation agent workspaces. The
+      # path must be identical on the dispatcher container's filesystem AND
+      # on the host the podman socket targets — we satisfy that by mounting
+      # the named volume at the same path on both sides (issue #1042).
+      Dispatcher__WorkspaceRoot: ${SPRING_DISPATCHER_WORKSPACE_ROOT:-/var/lib/spring-workspaces}
     command: ["dotnet", "/app/Cvoya.Spring.Dispatcher.dll"]
     # The dispatcher needs a reachable podman socket. On Linux this is the
     # rootless user-socket; on macOS the podman machine forwards the socket
@@ -206,8 +216,14 @@ services:
     # to the dispatcher on SELinux-enforcing hosts (Fedora CoreOS Podman
     # machines, RHEL/Fedora). Private-relabel — safe here because the
     # socket is single-consumer; must NOT be applied to shared volumes.
+    #
+    # spring-agent-workspaces is a named volume the dispatcher uses as the
+    # root for per-invocation agent workspaces. Agent containers receive
+    # their bind mount dynamically from the dispatcher at run-time — the
+    # mount only needs to be declared on the dispatcher itself.
     volumes:
       - ${SPRING_DISPATCHER_PODMAN_SOCKET:-/run/podman/podman.sock}:/run/podman/podman.sock:Z
+      - spring-agent-workspaces:${SPRING_DISPATCHER_WORKSPACE_ROOT:-/var/lib/spring-workspaces}
     networks: [spring-net]
     build:
       context: ..

--- a/deployment/spring.env.example
+++ b/deployment/spring.env.example
@@ -239,6 +239,17 @@ DEPLOY_HOSTNAME=localhost
 # SPRING_DISPATCHER_WORKER_TOKEN=change-me-to-a-random-secret
 # SPRING_DEFAULT_TENANT_ID=default
 # SPRING_DISPATCHER_PODMAN_SOCKET=/run/user/1000/podman/podman.sock
+#
+# SPRING_DISPATCHER_WORKSPACE_ROOT — host path INSIDE the dispatcher
+# container where the dispatcher writes per-invocation agent workspaces
+# (CLAUDE.md, AGENTS.md, .mcp.json, etc.) before bind-mounting them into
+# the agent containers it launches via podman (issue #1042). Defaults to
+# /var/lib/spring-workspaces. The deploy script bind-mounts a named
+# volume (`spring-agent-workspaces`) at this path on the dispatcher;
+# downstream operators can swap the named volume for a host path if they
+# need persistent or shared storage. The dispatcher refuses to start if
+# this directory is missing or read-only.
+# SPRING_DISPATCHER_WORKSPACE_ROOT=/var/lib/spring-workspaces
 
 # ---------------------------------------------------------------------------
 # Tier-1 platform secrets — identity of the Spring Voyage instance itself.

--- a/docs/architecture/deployment.md
+++ b/docs/architecture/deployment.md
@@ -119,7 +119,7 @@ Selection of the dispatcher's own backend is driven by `ContainerRuntime:Runtime
 - **The dispatcher needs a reachable container socket.** In the OSS standalone deployment the dispatcher container bind-mounts the host's rootless podman socket (`/run/user/${UID}/podman/podman.sock`) at `/run/podman/podman.sock` and uses `podman-remote` against it.
 - **Network reachability** for `host.docker.internal` — Linux hosts need Podman 4.1+ or an explicit `--add-host=host.docker.internal:host-gateway` (which the dispatcher adds automatically). This is how the in-container agent tool reaches the host's MCP server.
 - **TCP port 8999 free on `localhost`** — persistent agent containers publish their A2A endpoint on this port. (Future work will introduce per-agent port allocation; see `A2AExecutionDispatcher.SidecarPort`.)
-- **Writable temp directory** on the dispatcher host — each launcher materialises a per-invocation working directory under `Path.GetTempPath()` before the container starts.
+- **Writable workspace root on the dispatcher host** — the dispatcher materialises every per-invocation agent workspace under `Dispatcher:WorkspaceRoot` (default `/var/lib/spring-workspaces`) and bind-mounts it into the agent container. The OSS deployment scripts mount the named volume `spring-agent-workspaces` at this path so the host's podman can resolve the bind-mount source. Workers no longer write any workspace files of their own — see [Per-invocation workspace materialisation](#per-invocation-workspace-materialisation) below and issue #1042.
 
 ---
 
@@ -145,7 +145,19 @@ spring-worker
 | DELETE | `/v1/containers/{id}`       | Stop and remove a running container. 404 is treated as a no-op (already gone) to keep parity with the in-process runtime. |
 | GET    | `/health`                   | Unauthenticated liveness. |
 
-Request and response bodies are JSON. The request shape is close to `Cvoya.Spring.Core.Execution.ContainerConfig` — `image`, `command`, `env`, `mounts`, `workdir`, `timeoutSeconds`, `network`, `labels`, `extraHosts`, `detached`. The response is `{ id, exitCode?, stdout?, stderr? }`.
+Request and response bodies are JSON. The request shape is close to `Cvoya.Spring.Core.Execution.ContainerConfig` — `image`, `command`, `env`, `mounts`, `workdir`, `timeoutSeconds`, `network`, `labels`, `extraHosts`, `detached`, plus an optional `workspace: { mountPath, files }` envelope (see below). The response is `{ id, exitCode?, stdout?, stderr? }`.
+
+### Per-invocation workspace materialisation
+
+Agent launchers (`ClaudeCodeLauncher`, `CodexLauncher`, `GeminiLauncher`, `DaprAgentLauncher`) describe the workspace they need as **pure data** — a `WorkspaceFiles` map keyed by relative path plus a `WorkspaceMountPath` — and the dispatcher materialises that workspace on its own host filesystem before launching the agent container. Concretely, when a `POST /v1/containers` request includes a `workspace` envelope:
+
+1. The dispatcher creates a unique subdirectory under `Dispatcher:WorkspaceRoot` (`spring-ws-<guid>`).
+2. It writes each requested file into the subdirectory, creating parent directories as needed. Absolute paths and `..` traversals are rejected with `400 workspace_invalid`.
+3. It synthesises a bind-mount spec `<host-subdir>:<mountPath>` and appends it to the container's mounts.
+4. It defaults `workdir` to `mountPath` if the request did not specify one.
+5. For blocking runs (`detached=false`) it deletes the subdirectory after the runtime returns. For detached starts (`detached=true`) it tracks the subdirectory against the returned container id and deletes it when `DELETE /v1/containers/{id}` arrives.
+
+This is why workers no longer carry the workspace mount themselves: the worker's filesystem is private to the worker container, so any path the worker created would be invisible to the host's podman that the dispatcher actually shells out against. Issue #1042 captured the failure mode (`exit code 125, no such file or directory` on every Claude Code dispatch) and ADR'd into "the dispatcher owns workspace materialisation" because the dispatcher is the one process that already has the right filesystem view.
 
 ### Authentication and tenant scoping
 

--- a/docs/architecture/workflows.md
+++ b/docs/architecture/workflows.md
@@ -106,7 +106,7 @@ At dispatch time it:
 3. Looks up the `IAgentToolLauncher` whose `Tool` property matches `execution.tool`.
 4. Issues a short-lived MCP session (`IMcpServer.IssueSession`) bound to `(agentId, conversationId)`.
 5. Assembles the full four-layer prompt via `IPromptAssembler` (Layers 1–4; see [Units & Agents](units.md)).
-6. Delegates filesystem preparation to the launcher, which returns the per-invocation working directory, env vars, and volume-mount specs.
+6. Asks the launcher to describe the workspace it needs (file contents, in-container mount path, env vars, extra mounts). The launcher does **not** touch the local filesystem — `spring-dispatcher` materialises that workspace on its host before starting the agent container (issue #1042; see [Deployment](deployment.md#per-invocation-workspace-materialisation)).
 7. Runs the container (`IContainerRuntime`) and either streams A2A messages (persistent) or collects stdout on exit (ephemeral today; see [Deployment](deployment.md) for the rolling move to A2A-everywhere).
 
 ### Launcher registry
@@ -114,8 +114,7 @@ At dispatch time it:
 `IAgentToolLauncher` (`Cvoya.Spring.Core/Execution/IAgentToolLauncher.cs`) is the per-tool extension point. Every launcher exposes:
 
 - A unique `Tool` string that matches `execution.tool` in the agent YAML.
-- `PrepareAsync(AgentLaunchContext, ct)` — materialises a per-invocation working directory and returns `AgentLaunchPrep` (working dir path, env vars, volume mounts).
-- `CleanupAsync(workingDirectory, ct)` — removes the working directory when the container exits.
+- `PrepareAsync(AgentLaunchContext, ct)` — returns `AgentLaunchPrep`, a pure data record describing the workspace files (relative path → text content), env vars, the in-container mount path, optional extra mounts, and the working directory inside the container. The launcher does not touch the host filesystem; `spring-dispatcher` materialises and cleans up the workspace on its own host (#1042).
 
 Launchers are enumerable-registered in `AddCvoyaSpringDapr`; `A2AExecutionDispatcher` indexes them by `Tool` using a case-insensitive dictionary built at construction time.
 
@@ -170,13 +169,14 @@ sequenceDiagram
     MCP-->>Disp: SessionToken
     Disp->>Disp: IPromptAssembler.AssembleAsync(msg, ctx)
     Disp->>Launcher: PrepareAsync(AgentLaunchContext)
-    Launcher-->>Disp: AgentLaunchPrep (workdir, envVars, mounts)
-    Disp->>Runtime: RunAsync(ContainerConfig)
+    Launcher-->>Disp: AgentLaunchPrep (files, envVars, mountPath, mounts)
+    Disp->>Runtime: RunAsync(ContainerConfig with Workspace)
+    Runtime->>Runtime: materialise workspace + bind-mount<br/>(spring-dispatcher host)
     Runtime->>Container: start (mount workdir, inject envVars)
     Container->>MCP: MCP calls (checkpoint, recallMemory, ...)
     Container-->>Runtime: stdout / exit code
+    Runtime->>Runtime: delete workspace subdir
     Runtime-->>Disp: ContainerResult
-    Disp->>Launcher: CleanupAsync(workdir)
     Disp->>MCP: RevokeSession(token)
     Disp-->>A: response Message
 ```

--- a/src/Cvoya.Spring.Core/Execution/IAgentToolLauncher.cs
+++ b/src/Cvoya.Spring.Core/Execution/IAgentToolLauncher.cs
@@ -4,12 +4,19 @@
 namespace Cvoya.Spring.Core.Execution;
 
 /// <summary>
-/// Prepares the container-launch contract (working directory, env vars, volume
-/// mounts) for one specific external agent tool. Different tools (Claude Code,
-/// Codex, Gemini CLI, …) materialise their configuration in different ways, so
-/// each gets its own launcher. The dispatcher selects the launcher matching the
+/// Describes the container-launch contract for one specific external agent
+/// tool. Different tools (Claude Code, Codex, Gemini CLI, …) materialise
+/// their per-invocation configuration differently, so each gets its own
+/// launcher. The dispatcher selects the launcher matching the
 /// <see cref="AgentExecutionConfig.Tool"/> of the resolved agent definition.
 /// </summary>
+/// <remarks>
+/// Launchers no longer touch the local filesystem: they describe the workspace
+/// they need (file contents keyed by relative path, plus the desired in-container
+/// mount path) and let the dispatcher service materialise that workspace on its
+/// own host filesystem. This is what allows the agent container's bind mount to
+/// resolve to a real path the container runtime can see — see issue #1042.
+/// </remarks>
 public interface IAgentToolLauncher
 {
     /// <summary>
@@ -19,15 +26,13 @@ public interface IAgentToolLauncher
     string Tool { get; }
 
     /// <summary>
-    /// Materialises a new per-invocation working directory on disk and returns
-    /// the container-launch pieces that the dispatcher must splice into
-    /// <see cref="ContainerConfig"/>. The returned <see cref="AgentLaunchPrep.WorkingDirectory"/>
-    /// must be passed to <see cref="CleanupAsync"/> when the container exits.
+    /// Builds the container-launch contract for one invocation. The returned
+    /// <see cref="AgentLaunchPrep"/> describes the workspace the dispatcher
+    /// must materialise (file contents keyed by relative path), the mount
+    /// path inside the container, and any extra env vars or volume mounts.
+    /// Launchers MUST NOT write to the local filesystem.
     /// </summary>
     Task<AgentLaunchPrep> PrepareAsync(AgentLaunchContext context, CancellationToken cancellationToken = default);
-
-    /// <summary>Deletes the working directory created by a prior <see cref="PrepareAsync"/> call.</summary>
-    Task CleanupAsync(string workingDirectory, CancellationToken cancellationToken = default);
 }
 
 /// <summary>
@@ -58,12 +63,30 @@ public record AgentLaunchContext(
     string? Model = null);
 
 /// <summary>
-/// Output of <see cref="IAgentToolLauncher.PrepareAsync"/>.
+/// Output of <see cref="IAgentToolLauncher.PrepareAsync"/>. Pure data — no
+/// on-disk state. The dispatcher materialises <see cref="WorkspaceFiles"/>
+/// into a fresh per-invocation directory on its own filesystem and bind-mounts
+/// it at <see cref="WorkspaceMountPath"/> inside the container.
 /// </summary>
-/// <param name="WorkingDirectory">Absolute path to the on-disk working directory the container mounts in.</param>
+/// <param name="WorkspaceFiles">
+/// File contents keyed by path relative to the workspace root
+/// (e.g. <c>"CLAUDE.md"</c>, <c>".mcp.json"</c>). Empty when the agent does
+/// not need a workspace materialised.
+/// </param>
 /// <param name="EnvironmentVariables">Env vars the dispatcher must add to the container (on top of its own baseline).</param>
-/// <param name="VolumeMounts">Additional volume-mount specs (beyond the working-directory mount).</param>
+/// <param name="WorkspaceMountPath">
+/// Absolute path inside the container where the dispatcher must bind-mount
+/// the materialised workspace (e.g. <c>"/workspace"</c>). Required whenever
+/// <see cref="WorkspaceFiles"/> is non-empty.
+/// </param>
+/// <param name="ExtraVolumeMounts">Additional volume-mount specs (beyond the workspace mount).</param>
+/// <param name="WorkingDirectory">
+/// Optional working directory inside the container. When <c>null</c>, the
+/// dispatcher uses <see cref="WorkspaceMountPath"/>.
+/// </param>
 public record AgentLaunchPrep(
-    string WorkingDirectory,
+    IReadOnlyDictionary<string, string> WorkspaceFiles,
     IReadOnlyDictionary<string, string> EnvironmentVariables,
-    IReadOnlyList<string> VolumeMounts);
+    string WorkspaceMountPath,
+    IReadOnlyList<string>? ExtraVolumeMounts = null,
+    string? WorkingDirectory = null);

--- a/src/Cvoya.Spring.Core/Execution/IContainerRuntime.cs
+++ b/src/Cvoya.Spring.Core/Execution/IContainerRuntime.cs
@@ -82,6 +82,18 @@ public interface IContainerRuntime
 /// <param name="DaprAppPort">The port the app listens on for Dapr to call.</param>
 /// <param name="ExtraHosts">Additional <c>host:IP</c> entries to add to the container's <c>/etc/hosts</c>. Used to expose the MCP server to Linux containers via <c>host.docker.internal:host-gateway</c>.</param>
 /// <param name="WorkingDirectory">Optional working directory inside the container.</param>
+/// <param name="Workspace">
+/// Optional per-invocation workspace materialised on the dispatcher host. When
+/// non-null, the dispatcher writes <see cref="ContainerWorkspace.Files"/> into
+/// a fresh per-invocation directory on its own filesystem, bind-mounts that
+/// directory at <see cref="ContainerWorkspace.MountPath"/> inside the
+/// container, and cleans the directory up when the run completes (or, for
+/// detached starts, when <c>StopAsync</c> is called for the resulting
+/// container id). This is the seam that fixes the "worker writes to its own
+/// /tmp, dispatcher tries to bind-mount a path that does not exist on the
+/// host" failure mode in containerised dispatcher deployments — see issue
+/// #1042.
+/// </param>
 public record ContainerConfig(
     string Image,
     string? Command = null,
@@ -94,7 +106,37 @@ public record ContainerConfig(
     string? DaprAppId = null,
     int? DaprAppPort = null,
     IReadOnlyList<string>? ExtraHosts = null,
-    string? WorkingDirectory = null);
+    string? WorkingDirectory = null,
+    ContainerWorkspace? Workspace = null);
+
+/// <summary>
+/// A per-invocation set of text files the dispatcher must materialise into a
+/// fresh directory on its own filesystem and bind-mount into the launched
+/// container at <see cref="MountPath"/>. Carried by
+/// <see cref="ContainerConfig.Workspace"/>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The worker no longer writes the agent's <c>CLAUDE.md</c> / <c>AGENTS.md</c>
+/// / <c>.mcp.json</c> files itself — those paths exist only on the worker
+/// container's private filesystem and are invisible to the host's container
+/// runtime. The launcher describes the desired workspace as a content map
+/// keyed by relative path; the dispatcher creates the per-invocation directory
+/// on its own filesystem (under <c>Dispatcher:WorkspaceRoot</c>), writes the
+/// files, and uses that host path as the bind-mount source. See issue #1042.
+/// </para>
+/// <para>
+/// Files are written verbatim — the dispatcher does not interpret content,
+/// re-encode, or apply templating. Relative paths may contain forward
+/// slashes; the dispatcher normalises directory separators before creating
+/// parent directories. Absolute paths and <c>..</c> traversals are rejected.
+/// </para>
+/// </remarks>
+/// <param name="MountPath">Absolute path inside the container where the dispatcher bind-mounts the materialised directory (e.g. <c>"/workspace"</c>).</param>
+/// <param name="Files">File contents keyed by path relative to the workspace root (e.g. <c>"CLAUDE.md"</c>, <c>".mcp.json"</c>, <c>"sub/dir/file.txt"</c>).</param>
+public record ContainerWorkspace(
+    string MountPath,
+    IReadOnlyDictionary<string, string> Files);
 
 /// <summary>
 /// Result of a container execution.

--- a/src/Cvoya.Spring.Dapr/Execution/A2AExecutionDispatcher.cs
+++ b/src/Cvoya.Spring.Dapr/Execution/A2AExecutionDispatcher.cs
@@ -137,12 +137,7 @@ public class A2AExecutionDispatcher(
                     "or switch the agent to hosting: persistent.");
             }
 
-            var config = new ContainerConfig(
-                Image: definition.Execution.Image,
-                EnvironmentVariables: prep.EnvironmentVariables,
-                VolumeMounts: prep.VolumeMounts,
-                ExtraHosts: ["host.docker.internal:host-gateway"],
-                WorkingDirectory: ClaudeCodeLauncher.WorkspaceMountPath);
+            var config = BuildContainerConfig(definition.Execution.Image, prep);
 
             string? containerName = null;
             await using var cancellationRegistration = cancellationToken.Register(() =>
@@ -167,8 +162,28 @@ public class A2AExecutionDispatcher(
         finally
         {
             mcpServer.RevokeSession(session.Token);
-            await launcher.CleanupAsync(prep.WorkingDirectory, CancellationToken.None);
+            // No CleanupAsync call — workspace materialisation/cleanup lives in
+            // the dispatcher service now (issue #1042).
         }
+    }
+
+    /// <summary>
+    /// Translates a launcher's <see cref="AgentLaunchPrep"/> into a
+    /// <see cref="ContainerConfig"/>. The launcher describes the workspace as
+    /// pure data; the dispatcher service materialises it on its host
+    /// filesystem and synthesises the bind-mount at run time. See issue #1042.
+    /// </summary>
+    private static ContainerConfig BuildContainerConfig(string image, AgentLaunchPrep prep)
+    {
+        return new ContainerConfig(
+            Image: image,
+            EnvironmentVariables: prep.EnvironmentVariables,
+            VolumeMounts: prep.ExtraVolumeMounts,
+            ExtraHosts: ["host.docker.internal:host-gateway"],
+            WorkingDirectory: prep.WorkingDirectory ?? prep.WorkspaceMountPath,
+            Workspace: new ContainerWorkspace(
+                MountPath: prep.WorkspaceMountPath,
+                Files: prep.WorkspaceFiles));
     }
 
     private async Task<SvMessage?> DispatchPersistentAsync(
@@ -252,14 +267,7 @@ public class A2AExecutionDispatcher(
             "Starting persistent agent {AgentId} with image {Image}",
             agentId, definition.Execution.Image);
 
-        var config = new ContainerConfig(
-            Image: definition.Execution.Image,
-            EnvironmentVariables: prep.EnvironmentVariables,
-            VolumeMounts: prep.VolumeMounts,
-            ExtraHosts: ["host.docker.internal:host-gateway"],
-            WorkingDirectory: prep.WorkingDirectory.Contains(':')
-                ? null // Volume mount spec — don't set working dir
-                : prep.WorkingDirectory);
+        var config = BuildContainerConfig(definition.Execution.Image, prep);
 
         var containerId = await containerRuntime.StartAsync(config, cancellationToken);
 

--- a/src/Cvoya.Spring.Dapr/Execution/ClaudeCodeLauncher.cs
+++ b/src/Cvoya.Spring.Dapr/Execution/ClaudeCodeLauncher.cs
@@ -10,14 +10,14 @@ using Cvoya.Spring.Core.Execution;
 using Microsoft.Extensions.Logging;
 
 /// <summary>
-/// <see cref="IAgentToolLauncher"/> for Claude Code containers. Materialises a
-/// per-invocation working directory containing:
+/// <see cref="IAgentToolLauncher"/> for Claude Code containers. Describes a
+/// per-invocation workspace containing:
 /// <list type="bullet">
 ///   <item><c>CLAUDE.md</c> — the assembled system prompt (all four layers).</item>
 ///   <item><c>.mcp.json</c> — MCP server endpoint + bearer token Claude Code will dial.</item>
 /// </list>
-/// The directory is bind-mounted at <c>/workspace</c> inside the container and
-/// <see cref="CleanupAsync"/> removes it after the run completes.
+/// The dispatcher materialises this workspace on its own host filesystem and
+/// bind-mounts it at <c>/workspace</c> inside the container — see issue #1042.
 /// </summary>
 public class ClaudeCodeLauncher(ILoggerFactory loggerFactory) : IAgentToolLauncher
 {
@@ -28,20 +28,10 @@ public class ClaudeCodeLauncher(ILoggerFactory loggerFactory) : IAgentToolLaunch
     public string Tool => "claude-code";
 
     /// <inheritdoc />
-    public async Task<AgentLaunchPrep> PrepareAsync(
+    public Task<AgentLaunchPrep> PrepareAsync(
         AgentLaunchContext context,
         CancellationToken cancellationToken = default)
     {
-        var workdir = Path.Combine(
-            Path.GetTempPath(),
-            "spring-claude-" + Guid.NewGuid().ToString("N"));
-        Directory.CreateDirectory(workdir);
-
-        await File.WriteAllTextAsync(
-            Path.Combine(workdir, "CLAUDE.md"),
-            context.Prompt,
-            cancellationToken);
-
         var mcpConfig = new
         {
             mcpServers = new Dictionary<string, object>
@@ -58,14 +48,15 @@ public class ClaudeCodeLauncher(ILoggerFactory loggerFactory) : IAgentToolLaunch
             }
         };
 
-        await File.WriteAllTextAsync(
-            Path.Combine(workdir, ".mcp.json"),
-            JsonSerializer.Serialize(mcpConfig, new JsonSerializerOptions { WriteIndented = true }),
-            cancellationToken);
+        var workspaceFiles = new Dictionary<string, string>
+        {
+            ["CLAUDE.md"] = context.Prompt,
+            [".mcp.json"] = JsonSerializer.Serialize(mcpConfig, new JsonSerializerOptions { WriteIndented = true })
+        };
 
         _logger.LogInformation(
-            "Prepared Claude Code working directory {Workdir} for agent {AgentId} conversation {ConversationId}",
-            workdir, context.AgentId, context.ConversationId);
+            "Prepared Claude Code workspace request ({FileCount} files) for agent {AgentId} conversation {ConversationId}",
+            workspaceFiles.Count, context.AgentId, context.ConversationId);
 
         var envVars = new Dictionary<string, string>
         {
@@ -76,32 +67,9 @@ public class ClaudeCodeLauncher(ILoggerFactory loggerFactory) : IAgentToolLaunch
             ["SPRING_SYSTEM_PROMPT"] = context.Prompt
         };
 
-        var mounts = new List<string>
-        {
-            $"{workdir}:{WorkspaceMountPath}"
-        };
-
-        return new AgentLaunchPrep(workdir, envVars, mounts);
-    }
-
-    /// <inheritdoc />
-    public Task CleanupAsync(string workingDirectory, CancellationToken cancellationToken = default)
-    {
-        try
-        {
-            if (Directory.Exists(workingDirectory))
-            {
-                Directory.Delete(workingDirectory, recursive: true);
-                _logger.LogDebug("Deleted Claude Code working directory {Workdir}", workingDirectory);
-            }
-        }
-        catch (Exception ex)
-        {
-            _logger.LogWarning(ex,
-                "Failed to delete Claude Code working directory {Workdir}; leaving in place for operator inspection.",
-                workingDirectory);
-        }
-
-        return Task.CompletedTask;
+        return Task.FromResult(new AgentLaunchPrep(
+            WorkspaceFiles: workspaceFiles,
+            EnvironmentVariables: envVars,
+            WorkspaceMountPath: WorkspaceMountPath));
     }
 }

--- a/src/Cvoya.Spring.Dapr/Execution/CodexLauncher.cs
+++ b/src/Cvoya.Spring.Dapr/Execution/CodexLauncher.cs
@@ -10,15 +10,15 @@ using Cvoya.Spring.Core.Execution;
 using Microsoft.Extensions.Logging;
 
 /// <summary>
-/// <see cref="IAgentToolLauncher"/> for OpenAI Codex containers. Materialises a
-/// per-invocation working directory containing:
+/// <see cref="IAgentToolLauncher"/> for OpenAI Codex containers. Describes a
+/// per-invocation workspace containing:
 /// <list type="bullet">
 ///   <item><c>AGENTS.md</c> — the assembled system prompt (all four layers).
 ///         Codex reads this file as its instructions equivalent of Claude Code's <c>CLAUDE.md</c>.</item>
 ///   <item><c>.mcp.json</c> — MCP server endpoint + bearer token the Codex agent will dial.</item>
 /// </list>
-/// The directory is bind-mounted at <c>/workspace</c> inside the container and
-/// <see cref="CleanupAsync"/> removes it after the run completes.
+/// The dispatcher materialises this workspace on its own host filesystem and
+/// bind-mounts it at <c>/workspace</c> inside the container — see issue #1042.
 /// <para>
 /// <b>Expected container image shape:</b> The image must bundle the Codex CLI
 /// and the A2A sidecar from <c>agents/a2a-sidecar/</c>. The sidecar wraps the
@@ -37,20 +37,10 @@ public class CodexLauncher(ILoggerFactory loggerFactory) : IAgentToolLauncher
     public string Tool => "codex";
 
     /// <inheritdoc />
-    public async Task<AgentLaunchPrep> PrepareAsync(
+    public Task<AgentLaunchPrep> PrepareAsync(
         AgentLaunchContext context,
         CancellationToken cancellationToken = default)
     {
-        var workdir = Path.Combine(
-            Path.GetTempPath(),
-            "spring-codex-" + Guid.NewGuid().ToString("N"));
-        Directory.CreateDirectory(workdir);
-
-        await File.WriteAllTextAsync(
-            Path.Combine(workdir, "AGENTS.md"),
-            context.Prompt,
-            cancellationToken);
-
         var mcpConfig = new
         {
             mcpServers = new Dictionary<string, object>
@@ -67,14 +57,15 @@ public class CodexLauncher(ILoggerFactory loggerFactory) : IAgentToolLauncher
             }
         };
 
-        await File.WriteAllTextAsync(
-            Path.Combine(workdir, ".mcp.json"),
-            JsonSerializer.Serialize(mcpConfig, new JsonSerializerOptions { WriteIndented = true }),
-            cancellationToken);
+        var workspaceFiles = new Dictionary<string, string>
+        {
+            ["AGENTS.md"] = context.Prompt,
+            [".mcp.json"] = JsonSerializer.Serialize(mcpConfig, new JsonSerializerOptions { WriteIndented = true })
+        };
 
         _logger.LogInformation(
-            "Prepared Codex working directory {Workdir} for agent {AgentId} conversation {ConversationId}",
-            workdir, context.AgentId, context.ConversationId);
+            "Prepared Codex workspace request ({FileCount} files) for agent {AgentId} conversation {ConversationId}",
+            workspaceFiles.Count, context.AgentId, context.ConversationId);
 
         var envVars = new Dictionary<string, string>
         {
@@ -85,32 +76,9 @@ public class CodexLauncher(ILoggerFactory loggerFactory) : IAgentToolLauncher
             ["SPRING_SYSTEM_PROMPT"] = context.Prompt
         };
 
-        var mounts = new List<string>
-        {
-            $"{workdir}:{WorkspaceMountPath}"
-        };
-
-        return new AgentLaunchPrep(workdir, envVars, mounts);
-    }
-
-    /// <inheritdoc />
-    public Task CleanupAsync(string workingDirectory, CancellationToken cancellationToken = default)
-    {
-        try
-        {
-            if (Directory.Exists(workingDirectory))
-            {
-                Directory.Delete(workingDirectory, recursive: true);
-                _logger.LogDebug("Deleted Codex working directory {Workdir}", workingDirectory);
-            }
-        }
-        catch (Exception ex)
-        {
-            _logger.LogWarning(ex,
-                "Failed to delete Codex working directory {Workdir}; leaving in place for operator inspection.",
-                workingDirectory);
-        }
-
-        return Task.CompletedTask;
+        return Task.FromResult(new AgentLaunchPrep(
+            WorkspaceFiles: workspaceFiles,
+            EnvironmentVariables: envVars,
+            WorkspaceMountPath: WorkspaceMountPath));
     }
 }

--- a/src/Cvoya.Spring.Dapr/Execution/DaprAgentLauncher.cs
+++ b/src/Cvoya.Spring.Dapr/Execution/DaprAgentLauncher.cs
@@ -9,21 +9,24 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
 /// <summary>
-/// <see cref="IAgentToolLauncher"/> for the Dapr Agent container.  Materialises
-/// a per-invocation working directory and sets the environment variables the
-/// Python Dapr Agent expects: MCP endpoint/token, LLM provider/model, and the
-/// assembled system prompt.
+/// <see cref="IAgentToolLauncher"/> for the Dapr Agent container. Sets the
+/// environment variables the Python Dapr Agent expects: MCP endpoint/token,
+/// LLM provider/model, and the assembled system prompt. The dispatcher
+/// materialises an empty per-invocation workspace and bind-mounts it at
+/// <c>/workspace</c> — the Dapr Agent currently consumes its prompt via
+/// <c>SPRING_SYSTEM_PROMPT</c>, but the workspace mount keeps the launch
+/// shape uniform across tool launchers.
 ///
 /// Unlike <see cref="ClaudeCodeLauncher"/> the Dapr Agent is an A2A-native
 /// service and does not need a sidecar adapter — it exposes the A2A endpoint
-/// directly.  The dispatcher reaches the agent on the container's
+/// directly. The dispatcher reaches the agent on the container's
 /// <c>AGENT_PORT</c> (default 8999).
 /// </summary>
 public class DaprAgentLauncher(
     IOptions<OllamaOptions> ollamaOptions,
     ILoggerFactory loggerFactory) : IAgentToolLauncher
 {
-    internal const string ContainerWorkspace = "/workspace";
+    internal const string WorkspaceMountPath = "/workspace";
 
     /// <summary>Default A2A port the Dapr Agent listens on.</summary>
     internal const int DefaultAgentPort = 8999;
@@ -38,14 +41,9 @@ public class DaprAgentLauncher(
         AgentLaunchContext context,
         CancellationToken cancellationToken = default)
     {
-        var workdir = Path.Combine(
-            Path.GetTempPath(),
-            "spring-dapr-agent-" + Guid.NewGuid().ToString("N"));
-        Directory.CreateDirectory(workdir);
-
         _logger.LogInformation(
-            "Prepared Dapr Agent working directory {Workdir} for agent {AgentId} conversation {ConversationId}",
-            workdir, context.AgentId, context.ConversationId);
+            "Prepared Dapr Agent launch request for agent {AgentId} conversation {ConversationId}",
+            context.AgentId, context.ConversationId);
 
         var opts = ollamaOptions.Value;
 
@@ -80,33 +78,9 @@ public class DaprAgentLauncher(
             envVars["OLLAMA_ENDPOINT"] = opts.BaseUrl;
         }
 
-        var mounts = new List<string>
-        {
-            $"{workdir}:{ContainerWorkspace}"
-        };
-
-        var prep = new AgentLaunchPrep(workdir, envVars, mounts);
-        return Task.FromResult(prep);
-    }
-
-    /// <inheritdoc />
-    public Task CleanupAsync(string workingDirectory, CancellationToken cancellationToken = default)
-    {
-        try
-        {
-            if (Directory.Exists(workingDirectory))
-            {
-                Directory.Delete(workingDirectory, recursive: true);
-                _logger.LogDebug("Deleted Dapr Agent working directory {Workdir}", workingDirectory);
-            }
-        }
-        catch (Exception ex)
-        {
-            _logger.LogWarning(ex,
-                "Failed to delete Dapr Agent working directory {Workdir}; leaving in place for operator inspection.",
-                workingDirectory);
-        }
-
-        return Task.CompletedTask;
+        return Task.FromResult(new AgentLaunchPrep(
+            WorkspaceFiles: new Dictionary<string, string>(),
+            EnvironmentVariables: envVars,
+            WorkspaceMountPath: WorkspaceMountPath));
     }
 }

--- a/src/Cvoya.Spring.Dapr/Execution/DispatcherClientContainerRuntime.cs
+++ b/src/Cvoya.Spring.Dapr/Execution/DispatcherClientContainerRuntime.cs
@@ -230,6 +230,15 @@ public class DispatcherClientContainerRuntime(
                 : new Dictionary<string, string>(config.Labels),
             ExtraHosts = config.ExtraHosts,
             Detached = detached,
+            Workspace = config.Workspace is { } ws
+                ? new DispatcherWorkspace
+                {
+                    MountPath = ws.MountPath,
+                    Files = ws.Files is IDictionary<string, string> mutable
+                        ? mutable
+                        : new Dictionary<string, string>(ws.Files),
+                }
+                : null,
         };
     }
 
@@ -257,6 +266,26 @@ public class DispatcherClientContainerRuntime(
         public IDictionary<string, string>? Labels { get; init; }
         public IReadOnlyList<string>? ExtraHosts { get; init; }
         public bool Detached { get; init; }
+
+        /// <summary>
+        /// Per-invocation workspace the dispatcher must materialise on its own
+        /// host filesystem and bind-mount into the container. <c>null</c>
+        /// means the worker is asking for a plain run with no workspace.
+        /// </summary>
+        public DispatcherWorkspace? Workspace { get; init; }
+    }
+
+    /// <summary>
+    /// Wire shape for the optional <c>workspace</c> field on
+    /// <see cref="DispatcherRunRequest"/>. The dispatcher creates a fresh
+    /// per-invocation directory, writes <see cref="Files"/> into it, and
+    /// bind-mounts that directory at <see cref="MountPath"/> inside the
+    /// container — see issue #1042.
+    /// </summary>
+    internal record DispatcherWorkspace
+    {
+        public required string MountPath { get; init; }
+        public required IDictionary<string, string> Files { get; init; }
     }
 
     /// <summary>

--- a/src/Cvoya.Spring.Dapr/Execution/GeminiLauncher.cs
+++ b/src/Cvoya.Spring.Dapr/Execution/GeminiLauncher.cs
@@ -10,15 +10,15 @@ using Cvoya.Spring.Core.Execution;
 using Microsoft.Extensions.Logging;
 
 /// <summary>
-/// <see cref="IAgentToolLauncher"/> for Gemini CLI containers. Materialises a
-/// per-invocation working directory containing:
+/// <see cref="IAgentToolLauncher"/> for Gemini CLI containers. Describes a
+/// per-invocation workspace containing:
 /// <list type="bullet">
 ///   <item><c>GEMINI.md</c> — the assembled system prompt (all four layers).
 ///         Gemini CLI reads this file as its instructions file.</item>
 ///   <item><c>.mcp.json</c> — MCP server endpoint + bearer token the Gemini agent will dial.</item>
 /// </list>
-/// The directory is bind-mounted at <c>/workspace</c> inside the container and
-/// <see cref="CleanupAsync"/> removes it after the run completes.
+/// The dispatcher materialises this workspace on its own host filesystem and
+/// bind-mounts it at <c>/workspace</c> inside the container — see issue #1042.
 /// <para>
 /// <b>Expected container image shape:</b> The image must bundle the Gemini CLI
 /// and the A2A sidecar from <c>agents/a2a-sidecar/</c>. The sidecar wraps the
@@ -37,20 +37,10 @@ public class GeminiLauncher(ILoggerFactory loggerFactory) : IAgentToolLauncher
     public string Tool => "gemini";
 
     /// <inheritdoc />
-    public async Task<AgentLaunchPrep> PrepareAsync(
+    public Task<AgentLaunchPrep> PrepareAsync(
         AgentLaunchContext context,
         CancellationToken cancellationToken = default)
     {
-        var workdir = Path.Combine(
-            Path.GetTempPath(),
-            "spring-gemini-" + Guid.NewGuid().ToString("N"));
-        Directory.CreateDirectory(workdir);
-
-        await File.WriteAllTextAsync(
-            Path.Combine(workdir, "GEMINI.md"),
-            context.Prompt,
-            cancellationToken);
-
         var mcpConfig = new
         {
             mcpServers = new Dictionary<string, object>
@@ -67,14 +57,15 @@ public class GeminiLauncher(ILoggerFactory loggerFactory) : IAgentToolLauncher
             }
         };
 
-        await File.WriteAllTextAsync(
-            Path.Combine(workdir, ".mcp.json"),
-            JsonSerializer.Serialize(mcpConfig, new JsonSerializerOptions { WriteIndented = true }),
-            cancellationToken);
+        var workspaceFiles = new Dictionary<string, string>
+        {
+            ["GEMINI.md"] = context.Prompt,
+            [".mcp.json"] = JsonSerializer.Serialize(mcpConfig, new JsonSerializerOptions { WriteIndented = true })
+        };
 
         _logger.LogInformation(
-            "Prepared Gemini working directory {Workdir} for agent {AgentId} conversation {ConversationId}",
-            workdir, context.AgentId, context.ConversationId);
+            "Prepared Gemini workspace request ({FileCount} files) for agent {AgentId} conversation {ConversationId}",
+            workspaceFiles.Count, context.AgentId, context.ConversationId);
 
         var envVars = new Dictionary<string, string>
         {
@@ -85,32 +76,9 @@ public class GeminiLauncher(ILoggerFactory loggerFactory) : IAgentToolLauncher
             ["SPRING_SYSTEM_PROMPT"] = context.Prompt
         };
 
-        var mounts = new List<string>
-        {
-            $"{workdir}:{WorkspaceMountPath}"
-        };
-
-        return new AgentLaunchPrep(workdir, envVars, mounts);
-    }
-
-    /// <inheritdoc />
-    public Task CleanupAsync(string workingDirectory, CancellationToken cancellationToken = default)
-    {
-        try
-        {
-            if (Directory.Exists(workingDirectory))
-            {
-                Directory.Delete(workingDirectory, recursive: true);
-                _logger.LogDebug("Deleted Gemini working directory {Workdir}", workingDirectory);
-            }
-        }
-        catch (Exception ex)
-        {
-            _logger.LogWarning(ex,
-                "Failed to delete Gemini working directory {Workdir}; leaving in place for operator inspection.",
-                workingDirectory);
-        }
-
-        return Task.CompletedTask;
+        return Task.FromResult(new AgentLaunchPrep(
+            WorkspaceFiles: workspaceFiles,
+            EnvironmentVariables: envVars,
+            WorkspaceMountPath: WorkspaceMountPath));
     }
 }

--- a/src/Cvoya.Spring.Dapr/Execution/PersistentAgentLifecycle.cs
+++ b/src/Cvoya.Spring.Dapr/Execution/PersistentAgentLifecycle.cs
@@ -131,15 +131,18 @@ public class PersistentAgentLifecycle(
 
         // We pass the (possibly overridden) image into the ContainerConfig so
         // the override path only affects this single deployment — the stored
-        // AgentExecutionConfig.Image is untouched.
+        // AgentExecutionConfig.Image is untouched. Workspace materialisation
+        // lives in the dispatcher service (issue #1042); the launcher only
+        // describes the workspace files + mount path here.
         var config = new ContainerConfig(
             Image: image,
             EnvironmentVariables: prep.EnvironmentVariables,
-            VolumeMounts: prep.VolumeMounts,
+            VolumeMounts: prep.ExtraVolumeMounts,
             ExtraHosts: ["host.docker.internal:host-gateway"],
-            WorkingDirectory: prep.WorkingDirectory.Contains(':')
-                ? null
-                : prep.WorkingDirectory);
+            WorkingDirectory: prep.WorkingDirectory ?? prep.WorkspaceMountPath,
+            Workspace: new ContainerWorkspace(
+                MountPath: prep.WorkspaceMountPath,
+                Files: prep.WorkspaceFiles));
 
         var containerId = await containerRuntime.StartAsync(config, cancellationToken);
         var endpoint = new Uri($"http://localhost:{A2AExecutionDispatcher.SidecarPort}/");

--- a/src/Cvoya.Spring.Dispatcher/ContainersEndpoints.cs
+++ b/src/Cvoya.Spring.Dispatcher/ContainersEndpoints.cs
@@ -54,6 +54,7 @@ public static class ContainersEndpoints
     internal static async Task<IResult> RunOrStartAsync(
         [FromBody] RunContainerRequest request,
         IContainerRuntime runtime,
+        IWorkspaceMaterializer workspaceMaterializer,
         ILoggerFactory loggerFactory,
         HttpContext httpContext,
         CancellationToken cancellationToken)
@@ -72,20 +73,49 @@ public static class ContainersEndpoints
             });
         }
 
+        // Materialise the workspace BEFORE building the config so the bind-mount
+        // spec and effective working directory both reference the dispatcher-host
+        // path the agent container will actually see (issue #1042).
+        MaterializedWorkspace? materialized = null;
+        if (request.Workspace is { } workspaceRequest)
+        {
+            try
+            {
+                materialized = await workspaceMaterializer.MaterializeAsync(
+                    workspaceRequest, cancellationToken);
+            }
+            catch (Exception ex) when (ex is InvalidOperationException or ArgumentException)
+            {
+                logger.LogWarning(
+                    EventIds.DispatcherRejected,
+                    ex,
+                    "Rejected container run: workspace request is invalid");
+                return Results.BadRequest(new DispatcherErrorResponse
+                {
+                    Code = "workspace_invalid",
+                    Message = ex.Message,
+                });
+            }
+        }
+
+        var mounts = BuildEffectiveMounts(request.Mounts, materialized);
+        var workdir = request.WorkingDirectory
+            ?? materialized?.MountPath;
+
         var config = new ContainerConfig(
             Image: request.Image,
             Command: request.Command,
             EnvironmentVariables: request.Env is null
                 ? null
                 : new Dictionary<string, string>(request.Env),
-            VolumeMounts: request.Mounts,
+            VolumeMounts: mounts,
             Timeout: request.TimeoutSeconds is { } ts ? TimeSpan.FromSeconds(ts) : null,
             NetworkName: request.NetworkName,
             Labels: request.Labels is null
                 ? null
                 : new Dictionary<string, string>(request.Labels),
             ExtraHosts: request.ExtraHosts,
-            WorkingDirectory: request.WorkingDirectory);
+            WorkingDirectory: workdir);
 
         if (request.Detached)
         {
@@ -93,22 +123,70 @@ public static class ContainersEndpoints
                 EventIds.ContainerStartRequested,
                 "Starting detached container image={Image}", request.Image);
 
-            var id = await runtime.StartAsync(config, cancellationToken);
-            return Results.Ok(new RunContainerResponse { Id = id });
+            try
+            {
+                var id = await runtime.StartAsync(config, cancellationToken);
+                if (materialized is not null)
+                {
+                    // Detached starts: defer cleanup until DELETE /v1/containers/{id}.
+                    workspaceMaterializer.TrackForContainer(id, materialized);
+                }
+                return Results.Ok(new RunContainerResponse { Id = id });
+            }
+            catch
+            {
+                // The runtime never owned the workspace, so a start failure means
+                // we leak the host dir unless we sweep it here.
+                if (materialized is not null)
+                {
+                    workspaceMaterializer.Cleanup(materialized);
+                }
+                throw;
+            }
         }
 
         logger.LogInformation(
             EventIds.ContainerRunRequested,
             "Running container image={Image}", request.Image);
 
-        var result = await runtime.RunAsync(config, cancellationToken);
-        return Results.Ok(new RunContainerResponse
+        try
         {
-            Id = result.ContainerId,
-            ExitCode = result.ExitCode,
-            StandardOutput = result.StandardOutput,
-            StandardError = result.StandardError,
-        });
+            var result = await runtime.RunAsync(config, cancellationToken);
+            return Results.Ok(new RunContainerResponse
+            {
+                Id = result.ContainerId,
+                ExitCode = result.ExitCode,
+                StandardOutput = result.StandardOutput,
+                StandardError = result.StandardError,
+            });
+        }
+        finally
+        {
+            // Blocking runs always clean up — success or failure. Cleanup is
+            // logged by the materialiser so operators can audit the lifecycle.
+            if (materialized is not null)
+            {
+                workspaceMaterializer.Cleanup(materialized);
+            }
+        }
+    }
+
+    private static IReadOnlyList<string>? BuildEffectiveMounts(
+        IReadOnlyList<string>? requested,
+        MaterializedWorkspace? materialized)
+    {
+        if (materialized is null)
+        {
+            return requested;
+        }
+
+        var mounts = new List<string>(requested?.Count + 1 ?? 1);
+        if (requested is { Count: > 0 })
+        {
+            mounts.AddRange(requested);
+        }
+        mounts.Add(materialized.MountSpec);
+        return mounts;
     }
 
     /// <summary>
@@ -159,6 +237,7 @@ public static class ContainersEndpoints
     internal static async Task<IResult> StopAsync(
         string id,
         IContainerRuntime runtime,
+        IWorkspaceMaterializer workspaceMaterializer,
         ILoggerFactory loggerFactory,
         CancellationToken cancellationToken)
     {
@@ -177,7 +256,16 @@ public static class ContainersEndpoints
             EventIds.ContainerStopRequested,
             "Stopping container id={ContainerId}", id);
 
-        await runtime.StopAsync(id, cancellationToken);
+        try
+        {
+            await runtime.StopAsync(id, cancellationToken);
+        }
+        finally
+        {
+            // Detached starts deferred workspace cleanup to this call —
+            // if no workspace was tracked for this id this is a no-op.
+            workspaceMaterializer.CleanupForContainer(id);
+        }
         return Results.NoContent();
     }
 }

--- a/src/Cvoya.Spring.Dispatcher/DispatcherContracts.cs
+++ b/src/Cvoya.Spring.Dispatcher/DispatcherContracts.cs
@@ -55,6 +55,39 @@ public record RunContainerRequest
     /// </summary>
     [JsonPropertyName("detached")]
     public bool Detached { get; init; }
+
+    /// <summary>
+    /// Optional per-invocation workspace the dispatcher must materialise on
+    /// its own host filesystem (under <c>Dispatcher:WorkspaceRoot</c>) and
+    /// bind-mount into the container at <see cref="WorkspaceRequest.MountPath"/>.
+    /// Synthesised mount is appended to <see cref="Mounts"/>; if
+    /// <see cref="WorkingDirectory"/> is null it defaults to the workspace
+    /// mount path. The dispatcher deletes the materialised directory when the
+    /// run completes (or, for detached starts, when <c>DELETE</c> is called
+    /// for the resulting container id). See issue #1042.
+    /// </summary>
+    [JsonPropertyName("workspace")]
+    public WorkspaceRequest? Workspace { get; init; }
+}
+
+/// <summary>
+/// Files the dispatcher must materialise into a fresh per-invocation directory
+/// before launching a container. Carried by <see cref="RunContainerRequest.Workspace"/>.
+/// </summary>
+public record WorkspaceRequest
+{
+    /// <summary>Absolute path inside the container where the dispatcher bind-mounts the workspace.</summary>
+    [JsonPropertyName("mountPath")]
+    public required string MountPath { get; init; }
+
+    /// <summary>
+    /// File contents keyed by path relative to the workspace root. Paths must
+    /// be relative; absolute paths or <c>..</c> traversals are rejected. The
+    /// dispatcher creates parent directories as needed and writes each file
+    /// with UTF-8 encoding.
+    /// </summary>
+    [JsonPropertyName("files")]
+    public required IDictionary<string, string> Files { get; init; }
 }
 
 /// <summary>

--- a/src/Cvoya.Spring.Dispatcher/DispatcherOptions.cs
+++ b/src/Cvoya.Spring.Dispatcher/DispatcherOptions.cs
@@ -18,6 +18,9 @@ public class DispatcherOptions
     /// <summary>Configuration section name.</summary>
     public const string SectionName = "Dispatcher";
 
+    /// <summary>Default value for <see cref="WorkspaceRoot"/>.</summary>
+    public const string DefaultWorkspaceRoot = "/var/lib/spring-workspaces";
+
     /// <summary>
     /// Per-worker bearer tokens. Keys are opaque token strings (issued at deploy
     /// time); values carry the tenant id the token is scoped to. Requests whose
@@ -28,6 +31,19 @@ public class DispatcherOptions
     /// </summary>
     public IDictionary<string, DispatcherTokenScope> Tokens { get; set; }
         = new Dictionary<string, DispatcherTokenScope>(StringComparer.Ordinal);
+
+    /// <summary>
+    /// Filesystem root the dispatcher uses for per-invocation agent
+    /// workspaces. Each <c>POST /v1/containers</c> with a workspace request
+    /// gets a unique subdirectory here, which the dispatcher then bind-mounts
+    /// into the agent container. The directory must exist on the dispatcher
+    /// process's filesystem AND be addressable by the host's container runtime
+    /// (the dispatcher's <c>podman</c> shells out against the host socket).
+    /// Defaults to <see cref="DefaultWorkspaceRoot"/>; the deployment scripts
+    /// pre-create this directory and bind-mount it into the dispatcher
+    /// container at the same path. See issue #1042.
+    /// </summary>
+    public string WorkspaceRoot { get; set; } = DefaultWorkspaceRoot;
 }
 
 /// <summary>

--- a/src/Cvoya.Spring.Dispatcher/Program.cs
+++ b/src/Cvoya.Spring.Dispatcher/Program.cs
@@ -29,14 +29,23 @@ builder.Services.AddOptions<ContainerRuntimeOptions>()
 // DispatcherClientContainerRuntime instead (registered in the Dapr DI layer).
 builder.Services.AddSingleton<IContainerRuntime, PodmanRuntime>();
 
+// Workspace materialiser: per-invocation agent workspaces are written here on
+// the dispatcher host, then bind-mounted into the agent container. Lives in
+// the dispatcher (not the worker) so the host's container runtime sees the
+// directory. See issue #1042.
+builder.Services.AddSingleton<IWorkspaceMaterializer, WorkspaceMaterializer>();
+
 // Startup probe: the configured container runtime binary must resolve on PATH
 // before the dispatcher accepts requests. Without this, a misconfigured image
 // (e.g. one that ships `podman-remote` but not `podman`) comes up healthy and
 // then 500s on every dispatch with "No such file or directory". See #984.
 builder.Services.TryAddSingleton<IContainerRuntimeBinaryProbe, ContainerRuntimeBinaryProbe>();
+builder.Services.TryAddSingleton<IWorkspaceRootProbe, WorkspaceRootProbe>();
 builder.Services.AddCvoyaSpringConfigurationValidator();
 builder.Services.TryAddEnumerable(
     ServiceDescriptor.Singleton<IConfigurationRequirement, ContainerRuntimeBinaryConfigurationRequirement>());
+builder.Services.TryAddEnumerable(
+    ServiceDescriptor.Singleton<IConfigurationRequirement, WorkspaceRootConfigurationRequirement>());
 
 // Bearer-token auth over DispatcherOptions.Tokens. Keeping the scheme minimal
 // — a downstream host that targets multi-tenant K8s deployments can swap in a

--- a/src/Cvoya.Spring.Dispatcher/WorkspaceMaterializer.cs
+++ b/src/Cvoya.Spring.Dispatcher/WorkspaceMaterializer.cs
@@ -1,0 +1,223 @@
+// Copyright CVOYA LLC. Licensed under the Business Source License 1.1.
+// See LICENSE.md in the project root for full license terms.
+
+namespace Cvoya.Spring.Dispatcher;
+
+using System.Collections.Concurrent;
+using System.Text;
+
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+/// <summary>
+/// Materialises per-invocation agent workspaces on the dispatcher's host
+/// filesystem and tracks them so the dispatcher can clean them up when the
+/// associated container exits (or, for detached starts, when a stop call
+/// arrives). Fixes the "worker writes to its own private /tmp, dispatcher
+/// tries to bind-mount a non-existent host path" failure from issue #1042.
+/// </summary>
+/// <remarks>
+/// Files are written verbatim — the materializer does not interpret content,
+/// re-encode, or apply templating. Relative paths may use either forward or
+/// platform-native separators; absolute paths and <c>..</c> traversals are
+/// rejected so workers cannot escape the workspace root.
+/// </remarks>
+public interface IWorkspaceMaterializer
+{
+    /// <summary>
+    /// Writes <paramref name="workspace"/> into a fresh per-invocation
+    /// directory under <c>Dispatcher:WorkspaceRoot</c> and returns a handle
+    /// describing the host directory and the bind-mount spec callers should
+    /// append to the container's mount list. Throws
+    /// <see cref="InvalidOperationException"/> for invalid relative paths.
+    /// </summary>
+    Task<MaterializedWorkspace> MaterializeAsync(
+        WorkspaceRequest workspace,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Records that <paramref name="materialized"/> belongs to
+    /// <paramref name="containerId"/> so a later <see cref="CleanupForContainer"/>
+    /// call (driven by <c>DELETE /v1/containers/{id}</c>) can delete it.
+    /// </summary>
+    void TrackForContainer(string containerId, MaterializedWorkspace materialized);
+
+    /// <summary>
+    /// Deletes any workspace previously associated with
+    /// <paramref name="containerId"/>. Safe to call when nothing is tracked.
+    /// </summary>
+    void CleanupForContainer(string containerId);
+
+    /// <summary>
+    /// Deletes the on-disk directory pointed to by
+    /// <paramref name="materialized"/>. Tolerates missing directories —
+    /// callers may invoke this from a <c>finally</c> block without
+    /// pre-checking existence.
+    /// </summary>
+    void Cleanup(MaterializedWorkspace materialized);
+}
+
+/// <summary>
+/// Result of <see cref="IWorkspaceMaterializer.MaterializeAsync"/>.
+/// </summary>
+/// <param name="HostDirectory">Absolute host path of the per-invocation directory the dispatcher just created.</param>
+/// <param name="MountPath">In-container path the host directory must be bind-mounted at.</param>
+/// <param name="MountSpec">Ready-to-pass bind-mount spec (<c>host:container[:ro|:rw]</c>) for <see cref="ContainerConfig.VolumeMounts"/>.</param>
+public record MaterializedWorkspace(
+    string HostDirectory,
+    string MountPath,
+    string MountSpec);
+
+/// <summary>
+/// Default <see cref="IWorkspaceMaterializer"/>. Uses the local filesystem
+/// rooted at <see cref="DispatcherOptions.WorkspaceRoot"/>.
+/// </summary>
+public sealed class WorkspaceMaterializer(
+    IOptions<DispatcherOptions> options,
+    ILoggerFactory loggerFactory) : IWorkspaceMaterializer
+{
+    private readonly ILogger _logger = loggerFactory.CreateLogger<WorkspaceMaterializer>();
+    private readonly DispatcherOptions _options = options.Value;
+    private readonly ConcurrentDictionary<string, MaterializedWorkspace> _byContainer =
+        new(StringComparer.Ordinal);
+
+    /// <inheritdoc />
+    public async Task<MaterializedWorkspace> MaterializeAsync(
+        WorkspaceRequest workspace,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(workspace);
+        if (string.IsNullOrWhiteSpace(workspace.MountPath))
+        {
+            throw new InvalidOperationException("Workspace mount path is required.");
+        }
+        if (!workspace.MountPath.StartsWith('/'))
+        {
+            throw new InvalidOperationException(
+                $"Workspace mount path '{workspace.MountPath}' must be an absolute path inside the container.");
+        }
+
+        var root = _options.WorkspaceRoot;
+        if (string.IsNullOrWhiteSpace(root))
+        {
+            throw new InvalidOperationException(
+                "Dispatcher:WorkspaceRoot is not configured. Set it to a writable host path (default: "
+                + DispatcherOptions.DefaultWorkspaceRoot + ").");
+        }
+
+        Directory.CreateDirectory(root);
+
+        var subdirName = "spring-ws-" + Guid.NewGuid().ToString("N");
+        var hostDir = Path.Combine(root, subdirName);
+        Directory.CreateDirectory(hostDir);
+
+        try
+        {
+            foreach (var (relativePath, content) in workspace.Files)
+            {
+                var safePath = SanitizeRelativePath(relativePath, hostDir);
+                var parent = Path.GetDirectoryName(safePath);
+                if (!string.IsNullOrEmpty(parent))
+                {
+                    Directory.CreateDirectory(parent);
+                }
+
+                await File.WriteAllTextAsync(safePath, content ?? string.Empty, Encoding.UTF8, cancellationToken);
+            }
+        }
+        catch
+        {
+            // Roll the host dir back if we failed mid-write so we don't leak
+            // a half-populated workspace into the workspace root.
+            TryDelete(hostDir);
+            throw;
+        }
+
+        var mountSpec = $"{hostDir}:{workspace.MountPath}";
+        _logger.LogInformation(
+            "Materialised workspace dir={HostDir} mount={MountPath} files={FileCount}",
+            hostDir, workspace.MountPath, workspace.Files.Count);
+
+        return new MaterializedWorkspace(hostDir, workspace.MountPath, mountSpec);
+    }
+
+    /// <inheritdoc />
+    public void TrackForContainer(string containerId, MaterializedWorkspace materialized)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(containerId);
+        ArgumentNullException.ThrowIfNull(materialized);
+
+        _byContainer[containerId] = materialized;
+        _logger.LogDebug(
+            "Tracking workspace dir={HostDir} for container {ContainerId}",
+            materialized.HostDirectory, containerId);
+    }
+
+    /// <inheritdoc />
+    public void CleanupForContainer(string containerId)
+    {
+        if (string.IsNullOrWhiteSpace(containerId))
+        {
+            return;
+        }
+        if (_byContainer.TryRemove(containerId, out var materialized))
+        {
+            Cleanup(materialized);
+        }
+    }
+
+    /// <inheritdoc />
+    public void Cleanup(MaterializedWorkspace materialized)
+    {
+        if (materialized is null)
+        {
+            return;
+        }
+        TryDelete(materialized.HostDirectory);
+    }
+
+    private void TryDelete(string hostDir)
+    {
+        try
+        {
+            if (Directory.Exists(hostDir))
+            {
+                Directory.Delete(hostDir, recursive: true);
+                _logger.LogInformation("Cleaned up workspace dir={HostDir}", hostDir);
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex,
+                "Failed to delete workspace dir={HostDir}; leaving in place for operator inspection.",
+                hostDir);
+        }
+    }
+
+    private static string SanitizeRelativePath(string relative, string hostDir)
+    {
+        if (string.IsNullOrWhiteSpace(relative))
+        {
+            throw new InvalidOperationException("Workspace file path must not be empty.");
+        }
+
+        // Reject anything that looks like an absolute path on either platform.
+        if (Path.IsPathRooted(relative) || relative.Contains(':'))
+        {
+            throw new InvalidOperationException(
+                $"Workspace file path '{relative}' must be relative.");
+        }
+
+        // Normalise separators and resolve the full path, then ensure it stays
+        // inside hostDir to block ../../etc/passwd-style escapes.
+        var normalized = relative.Replace('\\', '/');
+        var combined = Path.GetFullPath(Path.Combine(hostDir, normalized));
+        var rootFull = Path.GetFullPath(hostDir) + Path.DirectorySeparatorChar;
+        if (!combined.StartsWith(rootFull, StringComparison.Ordinal))
+        {
+            throw new InvalidOperationException(
+                $"Workspace file path '{relative}' escapes the workspace root.");
+        }
+        return combined;
+    }
+}

--- a/src/Cvoya.Spring.Dispatcher/WorkspaceRootConfigurationRequirement.cs
+++ b/src/Cvoya.Spring.Dispatcher/WorkspaceRootConfigurationRequirement.cs
@@ -1,0 +1,132 @@
+// Copyright CVOYA LLC. Licensed under the Business Source License 1.1.
+// See LICENSE.md in the project root for full license terms.
+
+namespace Cvoya.Spring.Dispatcher;
+
+using Cvoya.Spring.Core.Configuration;
+
+using Microsoft.Extensions.Options;
+
+/// <summary>
+/// Tier-1 requirement: the directory named by <see cref="DispatcherOptions.WorkspaceRoot"/>
+/// must exist on the dispatcher host filesystem and be writable. The
+/// dispatcher materialises per-invocation agent workspaces here and
+/// bind-mounts them into agent containers — so a missing or read-only root
+/// would make every <c>POST /v1/containers</c> with a workspace fail. Surfacing
+/// the misconfiguration at boot beats a runtime 500 storm. See issue #1042.
+/// </summary>
+public sealed class WorkspaceRootConfigurationRequirement(
+    IOptions<DispatcherOptions> optionsAccessor,
+    IWorkspaceRootProbe probe) : IConfigurationRequirement
+{
+    private readonly IOptions<DispatcherOptions> _options =
+        optionsAccessor ?? throw new ArgumentNullException(nameof(optionsAccessor));
+    private readonly IWorkspaceRootProbe _probe =
+        probe ?? throw new ArgumentNullException(nameof(probe));
+
+    /// <inheritdoc />
+    public string RequirementId => "dispatcher-workspace-root";
+
+    /// <inheritdoc />
+    public string DisplayName => "Dispatcher workspace root is writable";
+
+    /// <inheritdoc />
+    public string SubsystemName => "Dispatcher";
+
+    /// <inheritdoc />
+    public bool IsMandatory => true;
+
+    /// <inheritdoc />
+    public IReadOnlyList<string> EnvironmentVariableNames { get; } =
+        new[] { "Dispatcher__WorkspaceRoot" };
+
+    /// <inheritdoc />
+    public string? ConfigurationSectionPath => DispatcherOptions.SectionName + ":WorkspaceRoot";
+
+    /// <inheritdoc />
+    public string Description =>
+        "The directory named by Dispatcher:WorkspaceRoot must exist on the dispatcher host and be writable. The dispatcher materialises per-invocation agent workspaces here and bind-mounts them into agent containers (issue #1042).";
+
+    /// <inheritdoc />
+    public Uri? DocumentationUrl { get; } =
+        new Uri("https://github.com/cvoya-com/spring-voyage/blob/main/docs/architecture/deployment.md", UriKind.Absolute);
+
+    /// <inheritdoc />
+    public Task<ConfigurationRequirementStatus> ValidateAsync(CancellationToken cancellationToken)
+    {
+        var root = _options.Value.WorkspaceRoot;
+        if (string.IsNullOrWhiteSpace(root))
+        {
+            var reason = "Dispatcher:WorkspaceRoot is not configured.";
+            var suggestion = "Set Dispatcher:WorkspaceRoot to a writable host path (default: "
+                + DispatcherOptions.DefaultWorkspaceRoot + ").";
+            return Task.FromResult(ConfigurationRequirementStatus.Invalid(
+                reason, suggestion, new InvalidOperationException(reason + " " + suggestion)));
+        }
+
+        var (ok, error) = _probe.Probe(root, cancellationToken);
+        if (ok)
+        {
+            return Task.FromResult(ConfigurationRequirementStatus.Met());
+        }
+
+        var failureReason =
+            $"Dispatcher:WorkspaceRoot '{root}' is not usable: {error}. " +
+            "Workspace bind-mounts for agent containers will fail.";
+        var failureSuggestion =
+            $"Create the directory and grant the dispatcher user write access (e.g. `mkdir -p {root} && chown spring:spring {root}`), " +
+            "or bind-mount a host volume into the dispatcher container at this path.";
+        return Task.FromResult(ConfigurationRequirementStatus.Invalid(
+            failureReason,
+            failureSuggestion,
+            new InvalidOperationException(failureReason + " " + failureSuggestion)));
+    }
+}
+
+/// <summary>
+/// Abstracts "is this directory present and writable?" so the requirement is
+/// unit-testable without touching the real filesystem.
+/// </summary>
+public interface IWorkspaceRootProbe
+{
+    /// <summary>
+    /// Returns <c>(true, null)</c> when <paramref name="path"/> exists (or
+    /// can be created) and a temp file write succeeded; otherwise
+    /// <c>(false, errorMessage)</c>.
+    /// </summary>
+    (bool Ok, string? Error) Probe(string path, CancellationToken cancellationToken);
+}
+
+/// <summary>
+/// Default <see cref="IWorkspaceRootProbe"/>: ensures the directory exists
+/// (creating it when missing) and verifies the dispatcher process can write a
+/// throwaway probe file into it.
+/// </summary>
+public sealed class WorkspaceRootProbe : IWorkspaceRootProbe
+{
+    /// <inheritdoc />
+    public (bool Ok, string? Error) Probe(string path, CancellationToken cancellationToken)
+    {
+        try
+        {
+            Directory.CreateDirectory(path);
+        }
+        catch (Exception ex)
+        {
+            return (false, $"could not create directory: {ex.Message}");
+        }
+
+        var probeFile = Path.Combine(path, ".spring-dispatcher-write-probe-" + Guid.NewGuid().ToString("N"));
+        try
+        {
+            File.WriteAllText(probeFile, "ok");
+            File.Delete(probeFile);
+        }
+        catch (Exception ex)
+        {
+            return (false, $"write probe failed: {ex.Message}");
+        }
+
+        return (true, null);
+    }
+}

--- a/tests/Cvoya.Spring.Dapr.Tests/Execution/A2AExecutionDispatcherTests.cs
+++ b/tests/Cvoya.Spring.Dapr.Tests/Execution/A2AExecutionDispatcherTests.cs
@@ -50,10 +50,9 @@ public class A2AExecutionDispatcherTests
         _launcher.Tool.Returns("claude-code");
         _launcher.PrepareAsync(Arg.Any<AgentLaunchContext>(), Arg.Any<CancellationToken>())
             .Returns(new AgentLaunchPrep(
-                WorkingDirectory: "/tmp/test-workdir",
+                WorkspaceFiles: new Dictionary<string, string> { ["CLAUDE.md"] = "prepared" },
                 EnvironmentVariables: new Dictionary<string, string> { ["SPRING_SYSTEM_PROMPT"] = "prepared" },
-                VolumeMounts: ["/tmp/test-workdir:/workspace"]));
-        _launcher.CleanupAsync(Arg.Any<string>(), Arg.Any<CancellationToken>()).Returns(Task.CompletedTask);
+                WorkspaceMountPath: "/workspace"));
 
         _mcpServer.Endpoint.Returns("http://host.docker.internal:12345/mcp/");
         _mcpServer.IssueSession(Arg.Any<string>(), Arg.Any<string>())
@@ -183,7 +182,7 @@ public class A2AExecutionDispatcherTests
     }
 
     [Fact]
-    public async Task DispatchAsync_EphemeralAgent_CleansUpAndRevokesSession_OnSuccess()
+    public async Task DispatchAsync_EphemeralAgent_RevokesSession_OnSuccess()
     {
         var message = CreateMessage();
         _promptAssembler.AssembleAsync(message, Arg.Any<PromptAssemblyContext?>(), Arg.Any<CancellationToken>())
@@ -194,11 +193,10 @@ public class A2AExecutionDispatcherTests
         await _dispatcher.DispatchAsync(message, context: null, TestContext.Current.CancellationToken);
 
         _mcpServer.Received(1).RevokeSession("test-token");
-        await _launcher.Received(1).CleanupAsync("/tmp/test-workdir", Arg.Any<CancellationToken>());
     }
 
     [Fact]
-    public async Task DispatchAsync_EphemeralAgent_CleansUpAndRevokesSession_OnFailure()
+    public async Task DispatchAsync_EphemeralAgent_RevokesSession_OnFailure()
     {
         var message = CreateMessage();
         _promptAssembler.AssembleAsync(message, Arg.Any<PromptAssemblyContext?>(), Arg.Any<CancellationToken>())
@@ -210,7 +208,30 @@ public class A2AExecutionDispatcherTests
         await Should.ThrowAsync<InvalidOperationException>(act);
 
         _mcpServer.Received(1).RevokeSession("test-token");
-        await _launcher.Received(1).CleanupAsync("/tmp/test-workdir", Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task DispatchAsync_EphemeralAgent_ForwardsWorkspaceToContainerRuntime()
+    {
+        // Issue #1042: workspace materialisation moved to the dispatcher, so
+        // the dispatcher must thread the launcher's WorkspaceFiles +
+        // WorkspaceMountPath through ContainerConfig.Workspace (which the
+        // dispatcher-client serialises into the run request).
+        var message = CreateMessage();
+        _promptAssembler.AssembleAsync(message, Arg.Any<PromptAssemblyContext?>(), Arg.Any<CancellationToken>())
+            .Returns("p");
+        _containerRuntime.RunAsync(Arg.Any<ContainerConfig>(), Arg.Any<CancellationToken>())
+            .Returns(new ContainerResult("spring-exec-ws", 0, "", ""));
+
+        await _dispatcher.DispatchAsync(message, context: null, TestContext.Current.CancellationToken);
+
+        await _containerRuntime.Received(1).RunAsync(
+            Arg.Is<ContainerConfig>(c =>
+                c.Workspace != null &&
+                c.Workspace.MountPath == "/workspace" &&
+                c.Workspace.Files.ContainsKey("CLAUDE.md") &&
+                c.WorkingDirectory == "/workspace"),
+            Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -339,12 +360,12 @@ public class A2AExecutionDispatcherTests
 
         _launcher.PrepareAsync(Arg.Any<AgentLaunchContext>(), Arg.Any<CancellationToken>())
             .Returns(ci => new AgentLaunchPrep(
-                WorkingDirectory: "/tmp/test-workdir",
+                WorkspaceFiles: new Dictionary<string, string>(),
                 EnvironmentVariables: new Dictionary<string, string>
                 {
                     ["SPRING_SYSTEM_PROMPT"] = ci.ArgAt<AgentLaunchContext>(0).Prompt
                 },
-                VolumeMounts: []));
+                WorkspaceMountPath: "/workspace"));
 
         await _dispatcher.DispatchAsync(message, context: null, TestContext.Current.CancellationToken);
 

--- a/tests/Cvoya.Spring.Dapr.Tests/Execution/ClaudeCodeLauncherTests.cs
+++ b/tests/Cvoya.Spring.Dapr.Tests/Execution/ClaudeCodeLauncherTests.cs
@@ -38,7 +38,7 @@ public class ClaudeCodeLauncherTests
     }
 
     [Fact]
-    public async Task PrepareAsync_WritesPromptAndMcpConfig()
+    public async Task PrepareAsync_ReturnsWorkspaceFilesAndEnvVars_WithoutTouchingDisk()
     {
         var context = new AgentLaunchContext(
             AgentId: "ada",
@@ -47,53 +47,36 @@ public class ClaudeCodeLauncherTests
             McpEndpoint: "http://host.docker.internal:9999/mcp/",
             McpToken: "top-secret-token");
 
-        AgentLaunchPrep prep;
-        try
-        {
-            prep = await _launcher.PrepareAsync(context, TestContext.Current.CancellationToken);
+        // The launcher must not write to the local filesystem any more —
+        // workspace materialisation lives in the dispatcher (issue #1042).
+        // We snapshot the temp dir before the call so we can assert nothing
+        // new appeared.
+        var preExisting = new HashSet<string>(Directory.EnumerateFileSystemEntries(Path.GetTempPath()));
 
-            File.Exists(Path.Combine(prep.WorkingDirectory, "CLAUDE.md")).ShouldBeTrue();
-            File.Exists(Path.Combine(prep.WorkingDirectory, ".mcp.json")).ShouldBeTrue();
+        var prep = await _launcher.PrepareAsync(context, TestContext.Current.CancellationToken);
 
-            var promptOnDisk = await File.ReadAllTextAsync(
-                Path.Combine(prep.WorkingDirectory, "CLAUDE.md"),
-                TestContext.Current.CancellationToken);
-            promptOnDisk.ShouldBe(context.Prompt);
+        var postExisting = Directory.EnumerateFileSystemEntries(Path.GetTempPath());
+        postExisting.Where(p => !preExisting.Contains(p))
+            .ShouldBeEmpty("ClaudeCodeLauncher must not touch the local filesystem");
 
-            var mcpConfig = await File.ReadAllTextAsync(
-                Path.Combine(prep.WorkingDirectory, ".mcp.json"),
-                TestContext.Current.CancellationToken);
-            var parsed = JsonDocument.Parse(mcpConfig).RootElement;
-            var server = parsed.GetProperty("mcpServers").GetProperty("spring-voyage");
-            server.GetProperty("url").GetString().ShouldBe(context.McpEndpoint);
-            server.GetProperty("headers").GetProperty("Authorization").GetString()
-                .ShouldBe("Bearer top-secret-token");
+        prep.WorkspaceMountPath.ShouldBe("/workspace");
+        prep.WorkspaceFiles.Keys.ShouldBe(new[] { "CLAUDE.md", ".mcp.json" }, ignoreOrder: true);
+        prep.WorkspaceFiles["CLAUDE.md"].ShouldBe(context.Prompt);
 
-            prep.EnvironmentVariables["SPRING_AGENT_ID"].ShouldBe(context.AgentId);
-            prep.EnvironmentVariables["SPRING_CONVERSATION_ID"].ShouldBe(context.ConversationId);
-            prep.EnvironmentVariables["SPRING_MCP_ENDPOINT"].ShouldBe(context.McpEndpoint);
-            prep.EnvironmentVariables["SPRING_AGENT_TOKEN"].ShouldBe(context.McpToken);
-            prep.EnvironmentVariables["SPRING_SYSTEM_PROMPT"].ShouldBe(context.Prompt);
+        var parsed = JsonDocument.Parse(prep.WorkspaceFiles[".mcp.json"]).RootElement;
+        var server = parsed.GetProperty("mcpServers").GetProperty("spring-voyage");
+        server.GetProperty("url").GetString().ShouldBe(context.McpEndpoint);
+        server.GetProperty("headers").GetProperty("Authorization").GetString()
+            .ShouldBe("Bearer top-secret-token");
 
-            prep.VolumeMounts.ShouldHaveSingleItem()
-                .ShouldBe($"{prep.WorkingDirectory}:/workspace");
-        }
-        finally
-        {
-            // Explicit cleanup in case the test body fails before calling CleanupAsync.
-        }
+        prep.EnvironmentVariables["SPRING_AGENT_ID"].ShouldBe(context.AgentId);
+        prep.EnvironmentVariables["SPRING_CONVERSATION_ID"].ShouldBe(context.ConversationId);
+        prep.EnvironmentVariables["SPRING_MCP_ENDPOINT"].ShouldBe(context.McpEndpoint);
+        prep.EnvironmentVariables["SPRING_AGENT_TOKEN"].ShouldBe(context.McpToken);
+        prep.EnvironmentVariables["SPRING_SYSTEM_PROMPT"].ShouldBe(context.Prompt);
 
-        await _launcher.CleanupAsync(prep.WorkingDirectory, TestContext.Current.CancellationToken);
-        Directory.Exists(prep.WorkingDirectory).ShouldBeFalse();
-    }
-
-    [Fact]
-    public async Task CleanupAsync_NonexistentDirectory_DoesNotThrow()
-    {
-        var nonexistent = Path.Combine(Path.GetTempPath(), "definitely-does-not-exist-" + Guid.NewGuid());
-
-        var act = () => _launcher.CleanupAsync(nonexistent, TestContext.Current.CancellationToken);
-
-        await Should.NotThrowAsync(act);
+        prep.ExtraVolumeMounts.ShouldBeNull();
+        prep.WorkingDirectory.ShouldBeNull(
+            "leaving WorkingDirectory unset lets the dispatcher default to WorkspaceMountPath");
     }
 }

--- a/tests/Cvoya.Spring.Dapr.Tests/Execution/CodexLauncherTests.cs
+++ b/tests/Cvoya.Spring.Dapr.Tests/Execution/CodexLauncherTests.cs
@@ -38,7 +38,7 @@ public class CodexLauncherTests
     }
 
     [Fact]
-    public async Task PrepareAsync_WritesPromptAndMcpConfig()
+    public async Task PrepareAsync_ReturnsWorkspaceFilesAndEnvVars_WithoutTouchingDisk()
     {
         var context = new AgentLaunchContext(
             AgentId: "codex-agent",
@@ -47,53 +47,31 @@ public class CodexLauncherTests
             McpEndpoint: "http://host.docker.internal:9999/mcp/",
             McpToken: "codex-secret-token");
 
-        AgentLaunchPrep prep;
-        try
-        {
-            prep = await _launcher.PrepareAsync(context, TestContext.Current.CancellationToken);
+        var preExisting = new HashSet<string>(Directory.EnumerateFileSystemEntries(Path.GetTempPath()));
 
-            File.Exists(Path.Combine(prep.WorkingDirectory, "AGENTS.md")).ShouldBeTrue();
-            File.Exists(Path.Combine(prep.WorkingDirectory, ".mcp.json")).ShouldBeTrue();
+        var prep = await _launcher.PrepareAsync(context, TestContext.Current.CancellationToken);
 
-            var promptOnDisk = await File.ReadAllTextAsync(
-                Path.Combine(prep.WorkingDirectory, "AGENTS.md"),
-                TestContext.Current.CancellationToken);
-            promptOnDisk.ShouldBe(context.Prompt);
+        var postExisting = Directory.EnumerateFileSystemEntries(Path.GetTempPath());
+        postExisting.Where(p => !preExisting.Contains(p))
+            .ShouldBeEmpty("CodexLauncher must not touch the local filesystem");
 
-            var mcpConfig = await File.ReadAllTextAsync(
-                Path.Combine(prep.WorkingDirectory, ".mcp.json"),
-                TestContext.Current.CancellationToken);
-            var parsed = JsonDocument.Parse(mcpConfig).RootElement;
-            var server = parsed.GetProperty("mcpServers").GetProperty("spring-voyage");
-            server.GetProperty("url").GetString().ShouldBe(context.McpEndpoint);
-            server.GetProperty("headers").GetProperty("Authorization").GetString()
-                .ShouldBe("Bearer codex-secret-token");
+        prep.WorkspaceMountPath.ShouldBe("/workspace");
+        prep.WorkspaceFiles.Keys.ShouldBe(new[] { "AGENTS.md", ".mcp.json" }, ignoreOrder: true);
+        prep.WorkspaceFiles["AGENTS.md"].ShouldBe(context.Prompt);
 
-            prep.EnvironmentVariables["SPRING_AGENT_ID"].ShouldBe(context.AgentId);
-            prep.EnvironmentVariables["SPRING_CONVERSATION_ID"].ShouldBe(context.ConversationId);
-            prep.EnvironmentVariables["SPRING_MCP_ENDPOINT"].ShouldBe(context.McpEndpoint);
-            prep.EnvironmentVariables["SPRING_AGENT_TOKEN"].ShouldBe(context.McpToken);
-            prep.EnvironmentVariables["SPRING_SYSTEM_PROMPT"].ShouldBe(context.Prompt);
+        var parsed = JsonDocument.Parse(prep.WorkspaceFiles[".mcp.json"]).RootElement;
+        var server = parsed.GetProperty("mcpServers").GetProperty("spring-voyage");
+        server.GetProperty("url").GetString().ShouldBe(context.McpEndpoint);
+        server.GetProperty("headers").GetProperty("Authorization").GetString()
+            .ShouldBe("Bearer codex-secret-token");
 
-            prep.VolumeMounts.ShouldHaveSingleItem()
-                .ShouldBe($"{prep.WorkingDirectory}:/workspace");
-        }
-        finally
-        {
-            // Explicit cleanup in case the test body fails before calling CleanupAsync.
-        }
+        prep.EnvironmentVariables["SPRING_AGENT_ID"].ShouldBe(context.AgentId);
+        prep.EnvironmentVariables["SPRING_CONVERSATION_ID"].ShouldBe(context.ConversationId);
+        prep.EnvironmentVariables["SPRING_MCP_ENDPOINT"].ShouldBe(context.McpEndpoint);
+        prep.EnvironmentVariables["SPRING_AGENT_TOKEN"].ShouldBe(context.McpToken);
+        prep.EnvironmentVariables["SPRING_SYSTEM_PROMPT"].ShouldBe(context.Prompt);
 
-        await _launcher.CleanupAsync(prep.WorkingDirectory, TestContext.Current.CancellationToken);
-        Directory.Exists(prep.WorkingDirectory).ShouldBeFalse();
-    }
-
-    [Fact]
-    public async Task CleanupAsync_NonexistentDirectory_DoesNotThrow()
-    {
-        var nonexistent = Path.Combine(Path.GetTempPath(), "definitely-does-not-exist-" + Guid.NewGuid());
-
-        var act = () => _launcher.CleanupAsync(nonexistent, TestContext.Current.CancellationToken);
-
-        await Should.NotThrowAsync(act);
+        prep.ExtraVolumeMounts.ShouldBeNull();
+        prep.WorkingDirectory.ShouldBeNull();
     }
 }

--- a/tests/Cvoya.Spring.Dapr.Tests/Execution/DaprAgentLauncherTests.cs
+++ b/tests/Cvoya.Spring.Dapr.Tests/Execution/DaprAgentLauncherTests.cs
@@ -43,20 +43,20 @@ public class DaprAgentLauncherTests
     }
 
     [Fact]
-    public async Task PrepareAsync_CreatesWorkingDirectory()
+    public async Task PrepareAsync_DoesNotTouchLocalFilesystem()
     {
-        var context = CreateContext();
+        // Issue #1042: launchers must no longer materialise workspace dirs on
+        // the worker side — the dispatcher owns that. Verify by snapshotting
+        // the temp dir before/after.
+        var preExisting = new HashSet<string>(Directory.EnumerateFileSystemEntries(Path.GetTempPath()));
 
-        var prep = await _launcher.PrepareAsync(context, TestContext.Current.CancellationToken);
+        var prep = await _launcher.PrepareAsync(CreateContext(), TestContext.Current.CancellationToken);
 
-        try
-        {
-            Directory.Exists(prep.WorkingDirectory).ShouldBeTrue();
-        }
-        finally
-        {
-            await _launcher.CleanupAsync(prep.WorkingDirectory, TestContext.Current.CancellationToken);
-        }
+        var postExisting = Directory.EnumerateFileSystemEntries(Path.GetTempPath());
+        postExisting.Where(p => !preExisting.Contains(p))
+            .ShouldBeEmpty("DaprAgentLauncher must not touch the local filesystem");
+
+        prep.WorkspaceMountPath.ShouldBe("/workspace");
     }
 
     [Fact]
@@ -66,40 +66,27 @@ public class DaprAgentLauncherTests
 
         var prep = await _launcher.PrepareAsync(context, TestContext.Current.CancellationToken);
 
-        try
-        {
-            prep.EnvironmentVariables["SPRING_AGENT_ID"].ShouldBe(context.AgentId);
-            prep.EnvironmentVariables["SPRING_CONVERSATION_ID"].ShouldBe(context.ConversationId);
-            prep.EnvironmentVariables["SPRING_MCP_ENDPOINT"].ShouldBe(context.McpEndpoint);
-            prep.EnvironmentVariables["SPRING_AGENT_TOKEN"].ShouldBe(context.McpToken);
-            prep.EnvironmentVariables["SPRING_SYSTEM_PROMPT"].ShouldBe(context.Prompt);
-            prep.EnvironmentVariables["SPRING_MODEL"].ShouldBe("llama3.2:3b");
-            prep.EnvironmentVariables["SPRING_LLM_PROVIDER"].ShouldBe("ollama");
-            prep.EnvironmentVariables["AGENT_PORT"].ShouldBe("8999");
-            prep.EnvironmentVariables["OLLAMA_ENDPOINT"].ShouldBe("http://spring-ollama:11434");
-        }
-        finally
-        {
-            await _launcher.CleanupAsync(prep.WorkingDirectory, TestContext.Current.CancellationToken);
-        }
+        prep.EnvironmentVariables["SPRING_AGENT_ID"].ShouldBe(context.AgentId);
+        prep.EnvironmentVariables["SPRING_CONVERSATION_ID"].ShouldBe(context.ConversationId);
+        prep.EnvironmentVariables["SPRING_MCP_ENDPOINT"].ShouldBe(context.McpEndpoint);
+        prep.EnvironmentVariables["SPRING_AGENT_TOKEN"].ShouldBe(context.McpToken);
+        prep.EnvironmentVariables["SPRING_SYSTEM_PROMPT"].ShouldBe(context.Prompt);
+        prep.EnvironmentVariables["SPRING_MODEL"].ShouldBe("llama3.2:3b");
+        prep.EnvironmentVariables["SPRING_LLM_PROVIDER"].ShouldBe("ollama");
+        prep.EnvironmentVariables["AGENT_PORT"].ShouldBe("8999");
+        prep.EnvironmentVariables["OLLAMA_ENDPOINT"].ShouldBe("http://spring-ollama:11434");
     }
 
     [Fact]
-    public async Task PrepareAsync_IncludesVolumeMount()
+    public async Task PrepareAsync_ProvidesEmptyWorkspace()
     {
-        var context = CreateContext();
+        // The Dapr Agent receives its prompt via SPRING_SYSTEM_PROMPT — so the
+        // requested workspace is empty (the dispatcher still mounts an empty
+        // dir at /workspace to keep the launch shape uniform across launchers).
+        var prep = await _launcher.PrepareAsync(CreateContext(), TestContext.Current.CancellationToken);
 
-        var prep = await _launcher.PrepareAsync(context, TestContext.Current.CancellationToken);
-
-        try
-        {
-            prep.VolumeMounts.ShouldHaveSingleItem()
-                .ShouldBe($"{prep.WorkingDirectory}:/workspace");
-        }
-        finally
-        {
-            await _launcher.CleanupAsync(prep.WorkingDirectory, TestContext.Current.CancellationToken);
-        }
+        prep.WorkspaceFiles.ShouldBeEmpty();
+        prep.WorkspaceMountPath.ShouldBe("/workspace");
     }
 
     [Fact]
@@ -111,15 +98,8 @@ public class DaprAgentLauncherTests
 
         var prep = await launcher.PrepareAsync(context, TestContext.Current.CancellationToken);
 
-        try
-        {
-            prep.EnvironmentVariables.ShouldNotContainKey("OLLAMA_ENDPOINT");
-            prep.EnvironmentVariables["SPRING_MODEL"].ShouldBe("phi3:mini");
-        }
-        finally
-        {
-            await launcher.CleanupAsync(prep.WorkingDirectory, TestContext.Current.CancellationToken);
-        }
+        prep.EnvironmentVariables.ShouldNotContainKey("OLLAMA_ENDPOINT");
+        prep.EnvironmentVariables["SPRING_MODEL"].ShouldBe("phi3:mini");
     }
 
     [Fact]
@@ -139,15 +119,8 @@ public class DaprAgentLauncherTests
 
         var prep = await _launcher.PrepareAsync(context, TestContext.Current.CancellationToken);
 
-        try
-        {
-            prep.EnvironmentVariables["SPRING_LLM_PROVIDER"].ShouldBe("openai");
-            prep.EnvironmentVariables["SPRING_MODEL"].ShouldBe("gpt-4o-mini");
-        }
-        finally
-        {
-            await _launcher.CleanupAsync(prep.WorkingDirectory, TestContext.Current.CancellationToken);
-        }
+        prep.EnvironmentVariables["SPRING_LLM_PROVIDER"].ShouldBe("openai");
+        prep.EnvironmentVariables["SPRING_MODEL"].ShouldBe("gpt-4o-mini");
     }
 
     [Fact]
@@ -160,36 +133,8 @@ public class DaprAgentLauncherTests
 
         var prep = await _launcher.PrepareAsync(context, TestContext.Current.CancellationToken);
 
-        try
-        {
-            prep.EnvironmentVariables["SPRING_LLM_PROVIDER"].ShouldBe("ollama");
-            prep.EnvironmentVariables["SPRING_MODEL"].ShouldBe("llama3.2:3b");
-        }
-        finally
-        {
-            await _launcher.CleanupAsync(prep.WorkingDirectory, TestContext.Current.CancellationToken);
-        }
-    }
-
-    [Fact]
-    public async Task CleanupAsync_DeletesWorkingDirectory()
-    {
-        var context = CreateContext();
-        var prep = await _launcher.PrepareAsync(context, TestContext.Current.CancellationToken);
-
-        await _launcher.CleanupAsync(prep.WorkingDirectory, TestContext.Current.CancellationToken);
-
-        Directory.Exists(prep.WorkingDirectory).ShouldBeFalse();
-    }
-
-    [Fact]
-    public async Task CleanupAsync_NonexistentDirectory_DoesNotThrow()
-    {
-        var nonexistent = Path.Combine(Path.GetTempPath(), "no-such-dir-" + Guid.NewGuid());
-
-        var act = () => _launcher.CleanupAsync(nonexistent, TestContext.Current.CancellationToken);
-
-        await Should.NotThrowAsync(act);
+        prep.EnvironmentVariables["SPRING_LLM_PROVIDER"].ShouldBe("ollama");
+        prep.EnvironmentVariables["SPRING_MODEL"].ShouldBe("llama3.2:3b");
     }
 
     private static AgentLaunchContext CreateContext() =>

--- a/tests/Cvoya.Spring.Dapr.Tests/Execution/DispatcherClientContainerRuntimeTests.cs
+++ b/tests/Cvoya.Spring.Dapr.Tests/Execution/DispatcherClientContainerRuntimeTests.cs
@@ -145,6 +145,47 @@ public class DispatcherClientContainerRuntimeTests
     }
 
     [Fact]
+    public async Task RunAsync_SerialisesWorkspaceField_WhenContainerConfigCarriesOne()
+    {
+        // Issue #1042: ContainerConfig.Workspace must round-trip into the wire
+        // body so the dispatcher service has the file map it needs to
+        // materialise the workspace on its host filesystem.
+        HttpRequestMessage? captured = null;
+        var handler = new FakeHandler(async (req, _) =>
+        {
+            captured = req;
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = JsonContent.Create(new { id = "ws-1", exitCode = 0, stdout = "", stderr = "" }),
+            };
+        });
+
+        var runtime = CreateRuntime(handler);
+
+        var config = new ContainerConfig(
+            Image: "claude-code:latest",
+            WorkingDirectory: "/workspace",
+            Workspace: new ContainerWorkspace(
+                MountPath: "/workspace",
+                Files: new Dictionary<string, string>
+                {
+                    ["CLAUDE.md"] = "system prompt",
+                    [".mcp.json"] = "{}",
+                }));
+
+        await runtime.RunAsync(config, TestContext.Current.CancellationToken);
+
+        captured.ShouldNotBeNull();
+        var body = await captured!.Content!.ReadAsStringAsync(TestContext.Current.CancellationToken);
+        using var parsed = JsonDocument.Parse(body);
+        var workspace = parsed.RootElement.GetProperty("workspace");
+        workspace.GetProperty("mountPath").GetString().ShouldBe("/workspace");
+        var files = workspace.GetProperty("files");
+        files.GetProperty("CLAUDE.md").GetString().ShouldBe("system prompt");
+        files.GetProperty(".mcp.json").GetString().ShouldBe("{}");
+    }
+
+    [Fact]
     public async Task RunAsync_MissingBaseUrl_Throws()
     {
         var handler = new FakeHandler(async (_, _) => new HttpResponseMessage(HttpStatusCode.OK));

--- a/tests/Cvoya.Spring.Dapr.Tests/Execution/GeminiLauncherTests.cs
+++ b/tests/Cvoya.Spring.Dapr.Tests/Execution/GeminiLauncherTests.cs
@@ -38,7 +38,7 @@ public class GeminiLauncherTests
     }
 
     [Fact]
-    public async Task PrepareAsync_WritesPromptAndMcpConfig()
+    public async Task PrepareAsync_ReturnsWorkspaceFilesAndEnvVars_WithoutTouchingDisk()
     {
         var context = new AgentLaunchContext(
             AgentId: "gemini-agent",
@@ -47,53 +47,31 @@ public class GeminiLauncherTests
             McpEndpoint: "http://host.docker.internal:9999/mcp/",
             McpToken: "gemini-secret-token");
 
-        AgentLaunchPrep prep;
-        try
-        {
-            prep = await _launcher.PrepareAsync(context, TestContext.Current.CancellationToken);
+        var preExisting = new HashSet<string>(Directory.EnumerateFileSystemEntries(Path.GetTempPath()));
 
-            File.Exists(Path.Combine(prep.WorkingDirectory, "GEMINI.md")).ShouldBeTrue();
-            File.Exists(Path.Combine(prep.WorkingDirectory, ".mcp.json")).ShouldBeTrue();
+        var prep = await _launcher.PrepareAsync(context, TestContext.Current.CancellationToken);
 
-            var promptOnDisk = await File.ReadAllTextAsync(
-                Path.Combine(prep.WorkingDirectory, "GEMINI.md"),
-                TestContext.Current.CancellationToken);
-            promptOnDisk.ShouldBe(context.Prompt);
+        var postExisting = Directory.EnumerateFileSystemEntries(Path.GetTempPath());
+        postExisting.Where(p => !preExisting.Contains(p))
+            .ShouldBeEmpty("GeminiLauncher must not touch the local filesystem");
 
-            var mcpConfig = await File.ReadAllTextAsync(
-                Path.Combine(prep.WorkingDirectory, ".mcp.json"),
-                TestContext.Current.CancellationToken);
-            var parsed = JsonDocument.Parse(mcpConfig).RootElement;
-            var server = parsed.GetProperty("mcpServers").GetProperty("spring-voyage");
-            server.GetProperty("url").GetString().ShouldBe(context.McpEndpoint);
-            server.GetProperty("headers").GetProperty("Authorization").GetString()
-                .ShouldBe("Bearer gemini-secret-token");
+        prep.WorkspaceMountPath.ShouldBe("/workspace");
+        prep.WorkspaceFiles.Keys.ShouldBe(new[] { "GEMINI.md", ".mcp.json" }, ignoreOrder: true);
+        prep.WorkspaceFiles["GEMINI.md"].ShouldBe(context.Prompt);
 
-            prep.EnvironmentVariables["SPRING_AGENT_ID"].ShouldBe(context.AgentId);
-            prep.EnvironmentVariables["SPRING_CONVERSATION_ID"].ShouldBe(context.ConversationId);
-            prep.EnvironmentVariables["SPRING_MCP_ENDPOINT"].ShouldBe(context.McpEndpoint);
-            prep.EnvironmentVariables["SPRING_AGENT_TOKEN"].ShouldBe(context.McpToken);
-            prep.EnvironmentVariables["SPRING_SYSTEM_PROMPT"].ShouldBe(context.Prompt);
+        var parsed = JsonDocument.Parse(prep.WorkspaceFiles[".mcp.json"]).RootElement;
+        var server = parsed.GetProperty("mcpServers").GetProperty("spring-voyage");
+        server.GetProperty("url").GetString().ShouldBe(context.McpEndpoint);
+        server.GetProperty("headers").GetProperty("Authorization").GetString()
+            .ShouldBe("Bearer gemini-secret-token");
 
-            prep.VolumeMounts.ShouldHaveSingleItem()
-                .ShouldBe($"{prep.WorkingDirectory}:/workspace");
-        }
-        finally
-        {
-            // Explicit cleanup in case the test body fails before calling CleanupAsync.
-        }
+        prep.EnvironmentVariables["SPRING_AGENT_ID"].ShouldBe(context.AgentId);
+        prep.EnvironmentVariables["SPRING_CONVERSATION_ID"].ShouldBe(context.ConversationId);
+        prep.EnvironmentVariables["SPRING_MCP_ENDPOINT"].ShouldBe(context.McpEndpoint);
+        prep.EnvironmentVariables["SPRING_AGENT_TOKEN"].ShouldBe(context.McpToken);
+        prep.EnvironmentVariables["SPRING_SYSTEM_PROMPT"].ShouldBe(context.Prompt);
 
-        await _launcher.CleanupAsync(prep.WorkingDirectory, TestContext.Current.CancellationToken);
-        Directory.Exists(prep.WorkingDirectory).ShouldBeFalse();
-    }
-
-    [Fact]
-    public async Task CleanupAsync_NonexistentDirectory_DoesNotThrow()
-    {
-        var nonexistent = Path.Combine(Path.GetTempPath(), "definitely-does-not-exist-" + Guid.NewGuid());
-
-        var act = () => _launcher.CleanupAsync(nonexistent, TestContext.Current.CancellationToken);
-
-        await Should.NotThrowAsync(act);
+        prep.ExtraVolumeMounts.ShouldBeNull();
+        prep.WorkingDirectory.ShouldBeNull();
     }
 }

--- a/tests/Cvoya.Spring.Dapr.Tests/Execution/PersistentDispatchIntegrationTests.cs
+++ b/tests/Cvoya.Spring.Dapr.Tests/Execution/PersistentDispatchIntegrationTests.cs
@@ -45,10 +45,9 @@ public class PersistentDispatchIntegrationTests
         _launcher.Tool.Returns("claude-code");
         _launcher.PrepareAsync(Arg.Any<AgentLaunchContext>(), Arg.Any<CancellationToken>())
             .Returns(new AgentLaunchPrep(
-                WorkingDirectory: "/tmp/test-workdir",
+                WorkspaceFiles: new Dictionary<string, string>(),
                 EnvironmentVariables: new Dictionary<string, string>(),
-                VolumeMounts: []));
-        _launcher.CleanupAsync(Arg.Any<string>(), Arg.Any<CancellationToken>()).Returns(Task.CompletedTask);
+                WorkspaceMountPath: "/workspace"));
 
         _mcpServer.Endpoint.Returns("http://host.docker.internal:12345/mcp/");
         _mcpServer.IssueSession(Arg.Any<string>(), Arg.Any<string>())

--- a/tests/Cvoya.Spring.Dispatcher.Tests/ContainersEndpointsTests.cs
+++ b/tests/Cvoya.Spring.Dispatcher.Tests/ContainersEndpointsTests.cs
@@ -166,4 +166,141 @@ public class ContainersEndpointsTests : IClassFixture<DispatcherWebApplicationFa
 
         response.StatusCode.ShouldBe(HttpStatusCode.OK);
     }
+
+    [Fact]
+    public async Task PostContainers_WithWorkspace_MaterialisesFilesAndAppendsBindMount()
+    {
+        _factory.ContainerRuntime.ClearSubstitute();
+
+        ContainerConfig? captured = null;
+        _factory.ContainerRuntime
+            .RunAsync(Arg.Do<ContainerConfig>(c => captured = c), Arg.Any<CancellationToken>())
+            .Returns(new ContainerResult("ws-blocking", 0, "ok", string.Empty));
+
+        var client = CreateAuthorizedClient();
+
+        var response = await client.PostAsJsonAsync("/v1/containers", new
+        {
+            image = "claude-code:latest",
+            workspace = new
+            {
+                mountPath = "/workspace",
+                files = new Dictionary<string, string>
+                {
+                    ["CLAUDE.md"] = "system prompt body",
+                    [".mcp.json"] = "{\"mcpServers\":{}}",
+                    ["nested/dir/note.txt"] = "nested",
+                },
+            },
+            detached = false,
+        }, TestContext.Current.CancellationToken);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        captured.ShouldNotBeNull();
+        captured!.WorkingDirectory.ShouldBe("/workspace");
+        var bindMount = captured.VolumeMounts!.Single();
+        bindMount.ShouldEndWith(":/workspace");
+
+        var hostDir = bindMount[..bindMount.LastIndexOf(":/workspace", StringComparison.Ordinal)];
+        Directory.Exists(hostDir).ShouldBeFalse(
+            "blocking runs must clean the materialised dir up after the runtime returns");
+        // The dir was materialised inside the configured root before being deleted.
+        hostDir.ShouldStartWith(_factory.WorkspaceRoot);
+    }
+
+    [Fact]
+    public async Task PostContainers_WithWorkspace_RejectsTraversalPaths()
+    {
+        _factory.ContainerRuntime.ClearSubstitute();
+
+        var client = CreateAuthorizedClient();
+
+        var response = await client.PostAsJsonAsync("/v1/containers", new
+        {
+            image = "claude-code:latest",
+            workspace = new
+            {
+                mountPath = "/workspace",
+                files = new Dictionary<string, string>
+                {
+                    ["../../etc/passwd"] = "x",
+                },
+            },
+        }, TestContext.Current.CancellationToken);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.BadRequest);
+        await _factory.ContainerRuntime.DidNotReceive().RunAsync(
+            Arg.Any<ContainerConfig>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task PostContainers_DetachedWithWorkspace_DefersCleanupUntilStop()
+    {
+        _factory.ContainerRuntime.ClearSubstitute();
+
+        ContainerConfig? captured = null;
+        _factory.ContainerRuntime
+            .StartAsync(Arg.Do<ContainerConfig>(c => captured = c), Arg.Any<CancellationToken>())
+            .Returns("persistent-ws-1");
+
+        var client = CreateAuthorizedClient();
+
+        var startResponse = await client.PostAsJsonAsync("/v1/containers", new
+        {
+            image = "agent:latest",
+            workspace = new
+            {
+                mountPath = "/workspace",
+                files = new Dictionary<string, string> { ["A.txt"] = "alpha" },
+            },
+            detached = true,
+        }, TestContext.Current.CancellationToken);
+
+        startResponse.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        captured.ShouldNotBeNull();
+        var bindMount = captured!.VolumeMounts!.Single();
+        var hostDir = bindMount[..bindMount.LastIndexOf(":/workspace", StringComparison.Ordinal)];
+        Directory.Exists(hostDir).ShouldBeTrue(
+            "detached starts must keep the workspace until DELETE is called");
+        File.ReadAllText(Path.Combine(hostDir, "A.txt")).ShouldBe("alpha");
+
+        var deleteResponse = await client.DeleteAsync(
+            "/v1/containers/persistent-ws-1", TestContext.Current.CancellationToken);
+        deleteResponse.StatusCode.ShouldBe(HttpStatusCode.NoContent);
+
+        Directory.Exists(hostDir).ShouldBeFalse(
+            "DELETE should sweep the workspace tracked by the detached start");
+    }
+
+    [Fact]
+    public async Task PostContainers_WithWorkspace_PreservesExistingMounts()
+    {
+        _factory.ContainerRuntime.ClearSubstitute();
+
+        ContainerConfig? captured = null;
+        _factory.ContainerRuntime
+            .RunAsync(Arg.Do<ContainerConfig>(c => captured = c), Arg.Any<CancellationToken>())
+            .Returns(new ContainerResult("ws-with-extra", 0, string.Empty, string.Empty));
+
+        var client = CreateAuthorizedClient();
+
+        var response = await client.PostAsJsonAsync("/v1/containers", new
+        {
+            image = "claude-code:latest",
+            mounts = new[] { "/var/run/secrets:/secrets:ro" },
+            workspace = new
+            {
+                mountPath = "/workspace",
+                files = new Dictionary<string, string> { ["CLAUDE.md"] = "x" },
+            },
+        }, TestContext.Current.CancellationToken);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        captured.ShouldNotBeNull();
+        captured!.VolumeMounts!.Count.ShouldBe(2);
+        captured.VolumeMounts.ShouldContain("/var/run/secrets:/secrets:ro");
+        captured.VolumeMounts.Last().ShouldEndWith(":/workspace");
+    }
 }

--- a/tests/Cvoya.Spring.Dispatcher.Tests/DispatcherWebApplicationFactory.cs
+++ b/tests/Cvoya.Spring.Dispatcher.Tests/DispatcherWebApplicationFactory.cs
@@ -33,10 +33,23 @@ public class DispatcherWebApplicationFactory : WebApplicationFactory<Program>
     /// <summary>Tenant id the <see cref="ValidToken"/> is scoped to.</summary>
     public const string ValidTenantId = "tenant-test";
 
+    /// <summary>
+    /// Per-fixture workspace root the dispatcher is configured to use. Lives
+    /// under <see cref="Path.GetTempPath"/> so the workspace materialiser can
+    /// write through the real filesystem during integration tests without
+    /// requiring the production default (<c>/var/lib/spring-workspaces</c>) to
+    /// exist.
+    /// </summary>
+    public string WorkspaceRoot { get; } =
+        Path.Combine(Path.GetTempPath(), "spring-dispatcher-tests-" + Guid.NewGuid().ToString("N"));
+
     /// <inheritdoc />
     protected override void ConfigureWebHost(IWebHostBuilder builder)
     {
+        Directory.CreateDirectory(WorkspaceRoot);
+
         builder.UseSetting($"{DispatcherOptions.SectionName}:Tokens:{ValidToken}:TenantId", ValidTenantId);
+        builder.UseSetting($"{DispatcherOptions.SectionName}:WorkspaceRoot", WorkspaceRoot);
 
         builder.ConfigureServices(services =>
         {
@@ -64,6 +77,27 @@ public class DispatcherWebApplicationFactory : WebApplicationFactory<Program>
             }
             services.AddSingleton<IContainerRuntimeBinaryProbe>(new StubContainerRuntimeBinaryProbe());
         });
+    }
+
+    /// <inheritdoc />
+    protected override void Dispose(bool disposing)
+    {
+        base.Dispose(disposing);
+        if (disposing)
+        {
+            try
+            {
+                if (Directory.Exists(WorkspaceRoot))
+                {
+                    Directory.Delete(WorkspaceRoot, recursive: true);
+                }
+            }
+            catch
+            {
+                // Best-effort cleanup — leaking a temp dir on test teardown is
+                // not worth failing the build over.
+            }
+        }
     }
 
     private sealed class StubContainerRuntimeBinaryProbe : IContainerRuntimeBinaryProbe


### PR DESCRIPTION
## Summary

Closes #1042. Workers used to materialise per-invocation agent
workspaces (`CLAUDE.md`, `AGENTS.md`, `.mcp.json`, …) into a temp
directory on the **worker container's** filesystem and pass that path
back to the dispatcher as the bind-mount source. Because the worker's
`/tmp` is private to the worker container, the host's `podman` (which
the dispatcher shells out against) saw no such path and refused to
start the agent container with **exit code 125** — no `claude-code`
agent could ever launch in the documented podman deployment. The same
pattern affected `CodexLauncher`, `GeminiLauncher`, and the empty
workdir created by `DaprAgentLauncher`.

## Architectural change

Workspace materialisation moves from the worker into `spring-dispatcher`
(option 3 from the issue):

- `IAgentToolLauncher.PrepareAsync` now returns a **pure-data**
  `AgentLaunchPrep` describing the workspace it needs:
  `WorkspaceFiles` (relative path → text content), `EnvironmentVariables`,
  the in-container `WorkspaceMountPath`, optional `ExtraVolumeMounts`,
  and the in-container `WorkingDirectory`. Launchers no longer touch the
  host filesystem and `CleanupAsync` is gone from the interface.
- `ContainerConfig` carries an optional `Workspace` field that
  `DispatcherClientContainerRuntime` serialises into the dispatcher's
  `RunContainerRequest` over the existing HTTP contract.
- `spring-dispatcher` now owns the workspace lifecycle:
  - Creates a unique per-invocation subdirectory under
    `Dispatcher:WorkspaceRoot` (default `/var/lib/spring-workspaces`).
  - Writes each requested file, creating parent directories. Absolute
    paths and `..` traversals are rejected with `400 workspace_invalid`.
  - Appends a `<host-subdir>:<MountPath>` bind-mount to the run config
    and defaults `workdir` to `MountPath` when none was supplied.
  - Deletes the subdirectory on completion of blocking runs (success
    or failure). For detached starts it tracks the subdir against the
    container id and deletes it when `DELETE /v1/containers/{id}`
    arrives.
- `WorkspaceRootConfigurationRequirement` validates that
  `Dispatcher:WorkspaceRoot` exists and is writable at startup, joining
  the existing `IConfigurationRequirement` family.
- `A2AExecutionDispatcher` and `PersistentAgentLifecycle` no longer call
  `CleanupAsync`; both build a single `ContainerConfig` carrying the
  workspace and let the dispatcher own the rest.

## Deployment notes

- `deployment/docker-compose.yml` and `deployment/deploy.sh` declare a
  new named volume `spring-agent-workspaces` and bind-mount it on the
  **dispatcher** container at the configured `WorkspaceRoot`. Workers
  no longer carry the workspace mount.
- `deployment/spring.env.example` documents the new
  `SPRING_DISPATCHER_WORKSPACE_ROOT` knob (defaults to
  `/var/lib/spring-workspaces`); operators can override it as long as
  the same path resolves on both the dispatcher container and the host
  the podman socket targets.
- Operators upgrading an existing deployment should `./deploy.sh down`
  + `./deploy.sh up` (or `restart`) so the dispatcher container is
  recreated with the new mount and env var. The host's podman socket
  configuration is unchanged.

## Documentation

- `docs/architecture/deployment.md` — adds the
  "Per-invocation workspace materialisation" section under the
  dispatcher service, updates the host-requirements list, and updates
  the HTTP contract row to mention the new `workspace` envelope.
- `docs/architecture/workflows.md` — refreshes the launcher contract,
  the ephemeral dispatch sequence diagram, and the registry bullets so
  they describe the data-only `AgentLaunchPrep` and the dispatcher-
  owned cleanup path.

## Test plan

- [x] `dotnet build SpringVoyage.slnx --configuration Release` (warnings-as-errors clean; the only warnings emitted are pre-existing Kiota OpenAPI EXEC warnings about `int32`/`int64` formats and are unrelated to this PR).
- [x] `dotnet test --solution SpringVoyage.slnx --no-restore --no-build --configuration Release` — **2685/2685 passing**.
- [x] `dotnet format`.
- [x] All four launcher tests asserts the new return shape and that no files appear under `Path.GetTempPath()`.
- [x] `A2AExecutionDispatcherTests` covers `Workspace` propagation into `ContainerConfig`.
- [x] `DispatcherClientContainerRuntimeTests` covers wire serialisation of the workspace field.
- [x] `ContainersEndpointsTests` covers materialisation, traversal rejection, deferred-cleanup-on-stop for detached runs, and preservation of pre-existing mounts.


Made with [Cursor](https://cursor.com)