### PR TITLE
fix: surface fresh agent replies in inbox list (closes #1210)

### DIFF
--- a/docs/guide/observing.md
+++ b/docs/guide/observing.md
@@ -82,7 +82,7 @@ The platform cancels any in-flight dispatch on every participating agent, remove
 
 ### Inbox: Things Awaiting You
 
-The inbox is the human-facing "things pointed at me that I have not responded to" surface. A conversation shows up here when the last event targets your `human://` address and you have not yet sent a follow-up; it drops off as soon as you respond or the agent retracts.
+The inbox is the human-facing "things pointed at me that I have not responded to" surface. A conversation shows up here when an agent (or unit) has delivered a message to your `human://` address and no other participant has observed a follow-up message after that point; it drops off as soon as you respond. Trailing observability events on the conversation (state changes from dispatch teardown, cost emissions) do not affect the inbox.
 
 ```
 spring inbox list                              # conversations awaiting a reply from you

--- a/src/Cvoya.Spring.Core/Observability/ConversationQueryModels.cs
+++ b/src/Cvoya.Spring.Core/Observability/ConversationQueryModels.cs
@@ -62,11 +62,15 @@ public record ConversationEvent(
 
 /// <summary>
 /// One row in a human's inbox (<c>GET /api/v1/inbox</c>). A conversation shows
-/// up here when the last event on the thread is a <c>MessageReceived</c> on a
-/// <c>human://</c> source matching the caller — i.e. "an agent said something
-/// to me and I haven't replied yet". Responding via
-/// <c>POST /api/v1/conversations/{id}/messages</c> (or the CLI's
-/// <c>spring inbox respond</c>) removes the row.
+/// up here when the human has a <c>MessageReceived</c> on the thread and no
+/// non-human actor has observed a <c>MessageReceived</c> after that point —
+/// i.e. "an agent said something to me and I haven't replied yet". The
+/// predicate is intentionally tolerant of trailing observability events
+/// (state changes, cost emissions) on the same conversation; only a follow-up
+/// <c>MessageReceived</c> from another participant clears the row (#1210).
+/// Responding via <c>POST /api/v1/conversations/{id}/messages</c> (or the
+/// CLI's <c>spring inbox respond</c>) removes the row by causing exactly that
+/// follow-up event.
 /// </summary>
 /// <param name="ConversationId">The conversation the ask belongs to.</param>
 /// <param name="From">The <c>scheme://path</c> of the actor that last spoke on the thread (the requester).</param>

--- a/src/Cvoya.Spring.Core/Observability/IConversationQueryService.cs
+++ b/src/Cvoya.Spring.Core/Observability/IConversationQueryService.cs
@@ -36,10 +36,14 @@ public interface IConversationQueryService
         CancellationToken cancellationToken);
 
     /// <summary>
-    /// Lists inbox rows for the supplied human address — conversations whose
-    /// most recent event is a <c>MessageReceived</c> on the human and where no
-    /// later event has been emitted by the same human. Rows drop off as soon
-    /// as the human acts or the agent retracts.
+    /// Lists inbox rows for the supplied human address — conversations where
+    /// the human has a <c>MessageReceived</c> event and no non-human actor
+    /// has observed a <c>MessageReceived</c> after that point on the same
+    /// conversation. Rows drop off when the human replies (and an agent /
+    /// unit on the other side acknowledges the reply with its own
+    /// <c>MessageReceived</c>). The predicate intentionally ignores trailing
+    /// observability events such as <c>StateChanged</c> from dispatch
+    /// teardown or <c>CostIncurred</c> from a budget enforcer (#1210).
     /// </summary>
     /// <param name="humanAddress">The <c>scheme://path</c> of the human whose inbox to load.</param>
     /// <param name="cancellationToken">A token to cancel the operation.</param>

--- a/src/Cvoya.Spring.Dapr/Observability/ConversationQueryService.cs
+++ b/src/Cvoya.Spring.Dapr/Observability/ConversationQueryService.cs
@@ -109,35 +109,75 @@ public class ConversationQueryService(SpringDbContext dbContext) : IConversation
 
         foreach (var group in rows.GroupBy(r => r.ConversationId))
         {
-            // A conversation is "in my inbox" when the most recent event on it
-            // is a MessageReceived emitted by MY human address and no later
-            // event from the same human cleared it.
+            // A conversation is "in my inbox" when the human has received a
+            // domain message on it and has not replied since. The reply
+            // signal is "another actor (non-human) emitted a MessageReceived
+            // on the same conversation AFTER the human's last
+            // MessageReceived" — that's the only path through which an
+            // agent / unit observes the human's follow-up. #1210: keying
+            // off "the LAST event must be the human's MessageReceived" was
+            // too narrow — trailing observability events on the same
+            // conversation (StateChanged on dispatch teardown, CostIncurred
+            // from a budget enforcer, future event types added by extension
+            // plugins) hid fresh agent replies even though the human had
+            // genuinely not responded. Keying off the most recent
+            // MessageReceived per side instead is robust to those tails.
             var ordered = group.OrderBy(r => r.Timestamp).ToList();
-            var last = ordered[^1];
 
-            if (!string.Equals(last.EventType, nameof(ActivityEventType.MessageReceived), StringComparison.Ordinal))
+            ConversationEventRow? humanReceive = null;
+            ConversationEventRow? laterAgentReceive = null;
+
+            for (var i = ordered.Count - 1; i >= 0; i--)
+            {
+                var row = ordered[i];
+                if (!string.Equals(row.EventType, nameof(ActivityEventType.MessageReceived), StringComparison.Ordinal))
+                {
+                    continue;
+                }
+
+                if (string.Equals(row.Source, humanSourceCanonical, StringComparison.OrdinalIgnoreCase))
+                {
+                    humanReceive = row;
+                    break;
+                }
+
+                if (laterAgentReceive is null
+                    && !row.Source.StartsWith("human:", StringComparison.OrdinalIgnoreCase))
+                {
+                    // Track the latest non-human MessageReceived; if it
+                    // comes after the human's, the human has already
+                    // replied and the conversation is no longer pending.
+                    laterAgentReceive = row;
+                }
+            }
+
+            if (humanReceive is null)
             {
                 continue;
             }
 
-            if (!string.Equals(last.Source, humanSourceCanonical, StringComparison.OrdinalIgnoreCase))
+            if (laterAgentReceive is not null && laterAgentReceive.Timestamp > humanReceive.Timestamp)
             {
                 continue;
             }
 
-            // Find the "from" — the most recent non-human event before the ask.
+            // Find the "from" — the most recent non-human source before the
+            // human's ask. Falls back to the human's own source when no
+            // upstream actor is present (a synthetic conversation seeded
+            // directly against the human address).
+            var humanIndex = ordered.IndexOf(humanReceive);
             var from = ordered
-                .TakeWhile(r => r != last)
+                .Take(humanIndex)
                 .Where(r => !r.Source.StartsWith("human:", StringComparison.OrdinalIgnoreCase))
                 .Select(r => NormaliseSource(r.Source))
-                .LastOrDefault() ?? NormaliseSource(last.Source);
+                .LastOrDefault() ?? NormaliseSource(humanReceive.Source);
 
             inbox.Add(new InboxItem(
                 ConversationId: group.Key,
                 From: from,
                 Human: humanSourceDisplay,
-                PendingSince: last.Timestamp,
-                Summary: last.Summary));
+                PendingSince: humanReceive.Timestamp,
+                Summary: humanReceive.Summary));
         }
 
         return inbox

--- a/tests/Cvoya.Spring.Dapr.Tests/Observability/ConversationQueryServiceTests.cs
+++ b/tests/Cvoya.Spring.Dapr.Tests/Observability/ConversationQueryServiceTests.cs
@@ -184,6 +184,117 @@ public class ConversationQueryServiceTests : IDisposable
         inbox.ShouldBeEmpty();
     }
 
+    [Fact]
+    public async Task ListInboxAsync_FreshAgentReply_AppearsInInbox()
+    {
+        // Reproduces #1210: a fresh agent → human reply should land in the
+        // inbox immediately. The on-the-wire event sequence emitted by the
+        // platform on a normal "human asks agent / agent answers" turn is:
+        //
+        //   1. agent:<id> MessageReceived       (AgentActor saw the human's message)
+        //   2. agent:<id> ConversationStarted   (HandleDomainMessageAsync, Case 1)
+        //   3. agent:<id> StateChanged          (Idle → Active, Debug severity)
+        //   4. human:<id> MessageReceived       (HumanActor saw the agent's reply)
+        //
+        // The inbox predicate keys off "last event is MessageReceived from
+        // the caller's human address", so this conversation must show up.
+        var t0 = DateTimeOffset.UtcNow.AddMinutes(-2);
+        await SeedConversationAsync("e58eaf86", new[]
+        {
+            ("agent:backend-engineer", "MessageReceived", "Received Domain message from human://local-dev-user", t0),
+            ("agent:backend-engineer", "ConversationStarted", "Started conversation e58eaf86", t0.AddMilliseconds(1)),
+            ("agent:backend-engineer", "StateChanged", "State changed from Idle to Active", t0.AddMilliseconds(2)),
+            ("human:local-dev-user", "MessageReceived", "Received Domain message from agent://backend-engineer", t0.AddMinutes(1)),
+        });
+
+        var svc = new ConversationQueryService(_db);
+        var inbox = await svc.ListInboxAsync("human://local-dev-user", TestContext.Current.CancellationToken);
+
+        inbox.Count.ShouldBe(1);
+        inbox[0].ConversationId.ShouldBe("e58eaf86");
+        inbox[0].Human.ShouldBe("human://local-dev-user");
+        inbox[0].From.ShouldBe("agent://backend-engineer");
+    }
+
+    [Fact]
+    public async Task ListInboxAsync_FreshReplyAlongsideStaleConversation_BothAppearMostRecentFirst()
+    {
+        // Variant of #1210: the user reported that a stale conversation from
+        // an earlier debug session was visible while a fresh reply was not.
+        // Both rows must appear, with the fresh row sorted ahead of the
+        // stale one (most recent PendingSince first).
+        var stale = DateTimeOffset.UtcNow.AddMinutes(-90);
+        var fresh = DateTimeOffset.UtcNow.AddMinutes(-1);
+        await SeedConversationAsync("5925edfa", new[]
+        {
+            ("agent:debug-agent", "ConversationStarted", "Started 5925edfa", stale.AddMinutes(-1)),
+            ("human:local-dev-user", "MessageReceived", "Stale ask", stale),
+        });
+        await SeedConversationAsync("e58eaf86", new[]
+        {
+            ("agent:backend-engineer", "MessageReceived", "Received Domain message", fresh.AddSeconds(-80)),
+            ("agent:backend-engineer", "ConversationStarted", "Started e58eaf86", fresh.AddSeconds(-79)),
+            ("human:local-dev-user", "MessageReceived", "Fresh reply", fresh),
+        });
+
+        var svc = new ConversationQueryService(_db);
+        var inbox = await svc.ListInboxAsync("human://local-dev-user", TestContext.Current.CancellationToken);
+
+        inbox.Count.ShouldBe(2);
+        inbox[0].ConversationId.ShouldBe("e58eaf86");
+        inbox[1].ConversationId.ShouldBe("5925edfa");
+    }
+
+    [Fact]
+    public async Task ListInboxAsync_TrailingStateChangedAfterHumanReceive_StillAppears()
+    {
+        // #1210 root cause: when the dispatch path emits a trailing event on
+        // the same correlation id (e.g. StateChanged from
+        // ClearActiveConversationAsync after a non-zero exit, future
+        // observability events from extension plugins, etc.), the inbox
+        // predicate must NOT drop the row. The human still hasn't replied,
+        // and the row has to stay visible until they do.
+        var t0 = DateTimeOffset.UtcNow.AddMinutes(-2);
+        await SeedConversationAsync("c-trailing", new[]
+        {
+            ("agent:ada", "MessageReceived", "Agent received human's ask", t0),
+            ("agent:ada", "ConversationStarted", "Started c-trailing", t0.AddMilliseconds(1)),
+            ("human:savasp", "MessageReceived", "Agent's reply", t0.AddSeconds(80)),
+            // Trailing event on the same conversation — e.g. a state
+            // teardown emitted by the agent after routing the response.
+            ("agent:ada", "StateChanged", "State changed from Active to Idle", t0.AddSeconds(81)),
+        });
+
+        var svc = new ConversationQueryService(_db);
+        var inbox = await svc.ListInboxAsync("human://savasp", TestContext.Current.CancellationToken);
+
+        inbox.Count.ShouldBe(1);
+        inbox[0].ConversationId.ShouldBe("c-trailing");
+        inbox[0].From.ShouldBe("agent://ada");
+    }
+
+    [Fact]
+    public async Task ListInboxAsync_HumanReceivedThenAgentReceivedAfter_DropsRow()
+    {
+        // The human replied — an agent emitted MessageReceived AFTER the
+        // human's last MessageReceived on the same conversation. The
+        // conversation must drop out of the inbox even if there are more
+        // trailing events afterwards.
+        var t0 = DateTimeOffset.UtcNow.AddMinutes(-5);
+        await SeedConversationAsync("c-replied", new[]
+        {
+            ("agent:ada", "MessageReceived", "Agent received human's first ask", t0),
+            ("human:savasp", "MessageReceived", "Agent's reply", t0.AddSeconds(60)),
+            ("agent:ada", "MessageReceived", "Agent received human's reply", t0.AddSeconds(120)),
+            ("agent:ada", "StateChanged", "Trailing tail", t0.AddSeconds(121)),
+        });
+
+        var svc = new ConversationQueryService(_db);
+        var inbox = await svc.ListInboxAsync("human://savasp", TestContext.Current.CancellationToken);
+
+        inbox.ShouldBeEmpty();
+    }
+
     private async Task SeedConversationAsync(
         string conversationId,
         (string source, string eventType, string summary, DateTimeOffset ts)[] events)


### PR DESCRIPTION
## Summary

- The inbox predicate gated visibility on "the last activity event on the conversation is a MessageReceived from my human address." That equality check is fragile to any trailing observability event on the same correlation id — `StateChanged` from `RunDispatchAsync`'s teardown path (#1059), `CostIncurred` from a budget enforcer, future event types added by extension plugins. The result: fresh agent replies disappear from `spring inbox list` even though the human has not responded.
- Switch to a per-side most-recent-MessageReceived comparison: a conversation is in the inbox when the human has a `MessageReceived` event and no non-human source has emitted a later `MessageReceived` on the same conversation. The "human replied" signal remains the same (an agent / unit observes the follow-up), so closing rows on reply still works exactly as before. Trailing state / cost events no longer affect visibility.
- Documented the new predicate on `InboxItem`, `IConversationQueryService.ListInboxAsync`, and `docs/guide/observing.md`. The `ConversationQueryService` carries an explanatory comment with the #1210 reference.

## Root cause

`ConversationQueryService.ListInboxAsync` looked at `ordered[^1]` and required:
- `last.EventType == "MessageReceived"`
- `last.Source == humanSourceCanonical`

If any later observability event landed on the conversation (e.g. an `Active → Idle` `StateChanged` from `ClearActiveConversationAsync` after a non-zero exit), `last` was that trailing event and the predicate failed. The hypothesis in #1210 about the agent-side state mutation hiding the conversation turned out to be the right shape but the wrong location — it was the inbox predicate that needed to tolerate the trailing tail, not the actor's state mutation that needed to change. Touching the actor's success path would conflict with #1085's single-active-conversation invariant; the query-side fix is local to the projection, leaves the actor state machine alone, and survives future event-type additions.

## Test plan

- [x] `ListInboxAsync_FreshAgentReply_AppearsInInbox` — reproduces the exact event sequence from #1210's repro and asserts the conversation surfaces.
- [x] `ListInboxAsync_FreshReplyAlongsideStaleConversation_BothAppearMostRecentFirst` — covers the symptom (a stale conversation visible while the fresh one is hidden) and asserts both rows appear with the fresh one sorted first.
- [x] `ListInboxAsync_TrailingStateChangedAfterHumanReceive_StillAppears` — pins the exact regression: a trailing `StateChanged` after the human's `MessageReceived` no longer drops the row.
- [x] `ListInboxAsync_HumanReceivedThenAgentReceivedAfter_DropsRow` — confirms the inverse case (human already replied) still drops out, including with a trailing state event after the reply.
- [x] All existing `ConversationQueryServiceTests` continue to pass.
- [x] Full `dotnet test` suite: 2900 / 2900 passing (7 skipped, none affected by this change).
- [x] `dotnet format --verify-no-changes`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)