### PR TITLE
refactor: update model type from 'sonnet' to 'opus' for multiple engineer roles

### DIFF
--- a/.claude/agents/cli-engineer.md
+++ b/.claude/agents/cli-engineer.md
@@ -1,7 +1,7 @@
 ---
 name: cli-engineer
 description: CLI engineer for Spring Voyage. Owns src/Cvoya.Spring.Cli/ — the `spring` CLI built on top of the public Web API. Use for CLI command authoring, Kiota client integration, validation/exit-code handling, and CLI-side end-to-end tests.
-model: sonnet
+model: opus
 tools: Bash, Read, Write, Edit, Glob, Grep, WebFetch
 ---
 

--- a/.claude/agents/connector-engineer.md
+++ b/.claude/agents/connector-engineer.md
@@ -1,7 +1,7 @@
 ---
 name: connector-engineer
 description: Implements Spring Voyage V2 connectors — inbound webhook translation and outbound skill exposure. Use for GitHub, Slack, or new connector implementations, webhook signature verification, and Octokit.net integration.
-model: sonnet
+model: opus
 tools: Bash, Read, Write, Edit, Glob, Grep, WebFetch
 ---
 

--- a/.claude/agents/devops-engineer.md
+++ b/.claude/agents/devops-engineer.md
@@ -1,7 +1,7 @@
 ---
 name: devops-engineer
 description: Handles Dapr component configuration, Dockerfiles, CI/CD pipelines, and build infrastructure for Spring Voyage V2. Use for container builds, deployment config, Dapr component YAML, and solution-level build changes.
-model: sonnet
+model: opus
 tools: Bash, Read, Write, Edit, Glob, Grep
 ---
 

--- a/.claude/agents/docs-writer.md
+++ b/.claude/agents/docs-writer.md
@@ -1,7 +1,7 @@
 ---
 name: docs-writer
 description: Owns Spring Voyage V2 documentation — architecture docs, concept docs, user guides, and decision records. Use for writing or updating docs/architecture/, docs/concepts/, docs/guide/, and docs/decisions/ when those changes are the primary work, not a side effect of an implementation PR.
-model: sonnet
+model: opus
 tools: Read, Write, Edit, Glob, Grep
 ---
 

--- a/.claude/agents/dotnet-engineer.md
+++ b/.claude/agents/dotnet-engineer.md
@@ -1,7 +1,7 @@
 ---
 name: dotnet-engineer
 description: Implements core Spring Voyage V2 platform features — Dapr actors, domain interfaces, message routing, orchestration strategies, prompt assembly, API host, worker host, and CLI. Use for any backend implementation task.
-model: sonnet
+model: opus
 tools: Bash, Read, Write, Edit, Glob, Grep, WebFetch
 ---
 

--- a/.claude/agents/qa-engineer.md
+++ b/.claude/agents/qa-engineer.md
@@ -1,7 +1,7 @@
 ---
 name: qa-engineer
 description: Writes and maintains tests for Spring Voyage V2 — unit, integration, and end-to-end. Use for test scaffolding, coverage gaps, xUnit/FluentAssertions patterns, Testcontainers integration tests, and Dapr test-mode wiring.
-model: sonnet
+model: opus
 tools: Bash, Read, Write, Edit, Glob, Grep
 ---
 

--- a/.claude/agents/web-engineer.md
+++ b/.claude/agents/web-engineer.md
@@ -1,7 +1,7 @@
 ---
 name: web-engineer
 description: Web / portal engineer for Spring Voyage. Owns the Next.js portal at src/Cvoya.Spring.Web/ (including the new unit/agent-interaction UX) plus connector-side web submodules. Use for portal feature work, the new agent-interaction UX, and any TypeScript/React changes under src/Cvoya.Spring.Web/ or connector web/ subprojects.
-model: sonnet
+model: opus
 tools: Bash, Read, Write, Edit, Glob, Grep, WebFetch
 ---
 


### PR DESCRIPTION
## Description

I noticed that some agents aren't making the best decisions so i am upgrading them all to opus.

## Related Issues

<!--
  Repeat the closing keyword before every issue number. GitHub's parser
  reliably auto-closes only when each number has its own keyword:
    Good:       Closes #64, closes #65, closes #66.
    Good:       one per line — `- Closes #64`
    Unreliable: Closes #64, #65, #66  (silently leaves #65/#66 open)
-->

## Changes

<!-- Brief list of what changed -->

-

## Testing

- [ ] `dotnet build` passes
- [ ] `dotnet test` passes
- [ ] `dotnet format --verify-no-changes` passes
- [ ] New/changed behavior has tests

## Checklist

- [ ] Changes follow [CONVENTIONS.md](../CONVENTIONS.md)
- [ ] No breaking changes to Core interfaces (or discussed in an issue first)
- [ ] Copyright headers on new C# files
- [ ] Docs updated alongside the code per [AGENTS.md § "Documentation Updates"](../AGENTS.md#documentation-updates): relevant `docs/architecture/` and `docs/guide/` entries refreshed, and `docs/concepts/` added/updated if a new concept is introduced (or N/A for doc-only/internal-only changes)
