### PR TITLE
[codex] Use GPT-5.5 xhigh for Codex agents

### DIFF
--- a/.codex/agents/api-designer.toml
+++ b/.codex/agents/api-designer.toml
@@ -1,6 +1,7 @@
 name = "api-designer"
 description = "Designs Spring Voyage v0.1 API contracts \u2014 HTTP endpoint shapes, A2A message contracts, Core domain interfaces, DTOs, and versioning strategy. Use for API surface design, contract review, backward-compatibility analysis, and extensibility planning."
-model = "opus"
+model = "gpt-5.5"
+model_reasoning_effort = "xhigh"
 developer_instructions = """# API Designer
 
 You are an API and contract design engineer for Spring Voyage v0.1.

--- a/.codex/agents/architect.toml
+++ b/.codex/agents/architect.toml
@@ -1,6 +1,7 @@
 name = "architect"
 description = "Platform architect for Spring Voyage. Owns ADRs, boundary design, and contracts/SDKs for SV-hosted agent developers. Use for architecture decisions, ADR authoring, boundary reviews, and component-API design."
-model = "opus"
+model = "gpt-5.5"
+model_reasoning_effort = "xhigh"
 developer_instructions = """# Architect
 
 Platform architect for Spring Voyage. Owns architecture decisions, boundary design, and ADR stewardship.

--- a/.codex/agents/cli-engineer.toml
+++ b/.codex/agents/cli-engineer.toml
@@ -1,6 +1,7 @@
 name = "cli-engineer"
 description = "CLI engineer for Spring Voyage. Owns src/Cvoya.Spring.Cli/ \u2014 the `spring` CLI built on top of the public Web API. Use for CLI command authoring, Kiota client integration, validation/exit-code handling, and CLI-side end-to-end tests."
-model = "opus"
+model = "gpt-5.5"
+model_reasoning_effort = "xhigh"
 developer_instructions = """# CLI Engineer
 
 CLI engineer for Spring Voyage. The CLI is the primary user experience for v0.1.

--- a/.codex/agents/connector-engineer.toml
+++ b/.codex/agents/connector-engineer.toml
@@ -1,6 +1,7 @@
 name = "connector-engineer"
 description = "Implements Spring Voyage v0.1 connectors \u2014 inbound webhook translation and outbound skill exposure. Use for GitHub, Slack, or new connector implementations, webhook signature verification, and Octokit.net integration."
-model = "opus"
+model = "gpt-5.5"
+model_reasoning_effort = "xhigh"
 developer_instructions = """# Connector Engineer
 
 Connector implementation engineer for Spring Voyage.

--- a/.codex/agents/design-engineer.toml
+++ b/.codex/agents/design-engineer.toml
@@ -1,6 +1,7 @@
 name = "design-engineer"
 description = "Owns the Spring Voyage portal UI/UX \u2014 design-system tokens, component patterns, layout, typography, accessibility, and DESIGN.md. Use for portal visual changes, dark-mode behavior, accessibility audits, and interaction flow reviews."
-model = "opus"
+model = "gpt-5.5"
+model_reasoning_effort = "xhigh"
 developer_instructions = """# Design Engineer
 
 You are a UI/UX design engineer for Spring Voyage v0.1.

--- a/.codex/agents/devops-engineer.toml
+++ b/.codex/agents/devops-engineer.toml
@@ -1,6 +1,7 @@
 name = "devops-engineer"
 description = "Handles Dapr component configuration, Dockerfiles, CI/CD pipelines, and build infrastructure for Spring Voyage v0.1. Use for container builds, deployment config, Dapr component YAML, and solution-level build changes."
-model = "opus"
+model = "gpt-5.5"
+model_reasoning_effort = "xhigh"
 developer_instructions = """# DevOps Engineer
 
 DevOps engineer for Spring Voyage.

--- a/.codex/agents/docs-writer.toml
+++ b/.codex/agents/docs-writer.toml
@@ -1,6 +1,7 @@
 name = "docs-writer"
 description = "Owns Spring Voyage v0.1 documentation \u2014 architecture docs, concept docs, user guides, and decision records. Use for writing or updating docs/architecture/, docs/concepts/, docs/guide/, and docs/decisions/ when those changes are the primary work, not a side effect of an implementation PR."
-model = "opus"
+model = "gpt-5.5"
+model_reasoning_effort = "xhigh"
 developer_instructions = """# Docs Writer
 
 You are the documentation engineer for Spring Voyage v0.1.

--- a/.codex/agents/dotnet-engineer.toml
+++ b/.codex/agents/dotnet-engineer.toml
@@ -1,6 +1,7 @@
 name = "dotnet-engineer"
 description = "Implements core Spring Voyage v0.1 platform features \u2014 Dapr actors, domain interfaces, message routing, orchestration strategies, prompt assembly, API host, worker host, and CLI. Use for any backend implementation task."
-model = "opus"
+model = "gpt-5.5"
+model_reasoning_effort = "xhigh"
 developer_instructions = """# .NET Engineer
 
 .NET / Dapr backend engineer for Spring Voyage.

--- a/.codex/agents/qa-engineer.toml
+++ b/.codex/agents/qa-engineer.toml
@@ -1,6 +1,7 @@
 name = "qa-engineer"
 description = "Writes and maintains tests for Spring Voyage v0.1 \u2014 unit, integration, and end-to-end. Use for test scaffolding, coverage gaps, xUnit/FluentAssertions patterns, Testcontainers integration tests, and Dapr test-mode wiring."
-model = "opus"
+model = "gpt-5.5"
+model_reasoning_effort = "xhigh"
 developer_instructions = """# QA Engineer
 
 QA / test engineer for Spring Voyage.

--- a/.codex/agents/security-engineer.toml
+++ b/.codex/agents/security-engineer.toml
@@ -1,6 +1,7 @@
 name = "security-engineer"
 description = "Audits Spring Voyage v0.1 code for security issues \u2014 tenant isolation violations, credential handling, DI bypass, hardcoded assumptions, and extensibility contract violations. Use for security reviews, threat modeling, and fixing identified vulnerabilities."
-model = "opus"
+model = "gpt-5.5"
+model_reasoning_effort = "xhigh"
 developer_instructions = """# Security Engineer
 
 You are the security engineer for Spring Voyage v0.1.

--- a/.codex/agents/web-engineer.toml
+++ b/.codex/agents/web-engineer.toml
@@ -1,6 +1,7 @@
 name = "web-engineer"
 description = "Web / portal engineer for Spring Voyage. Owns the Next.js portal at src/Cvoya.Spring.Web/ (including the new unit/agent-interaction UX) plus connector-side web submodules. Use for portal feature work, the new agent-interaction UX, and any TypeScript/React changes under src/Cvoya.Spring.Web/ or connector web/ subprojects."
-model = "opus"
+model = "gpt-5.5"
+model_reasoning_effort = "xhigh"
 developer_instructions = """# Web Engineer
 
 Web / portal engineer for Spring Voyage.


### PR DESCRIPTION
## Summary

Updates the repo-level Codex agent definitions to use `gpt-5.5` with `model_reasoning_effort = "xhigh"`.

## Why

The specialist Codex agents were configured with `model = "opus"`, which is not supported for Codex on this account and caused delegated agent startup to fail before task work began.

## Validation

- Parsed all 11 `.codex/agents/*.toml` files with Python `tomllib`.
- Confirmed no `.codex/agents/*.toml` file still contains the `opus` model setting.

## Impact

Future Codex specialist agents should resolve to the supported GPT-5.5 extra-high reasoning model while preserving their existing role instructions.