### PR TITLE
[codex] Optimize GitHub workflow triggers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,8 @@ jobs:
       python_agents: ${{ steps.filter.outputs.python_agents }}
       connectors_web: ${{ steps.filter.outputs.connectors_web }}
       web: ${{ steps.filter.outputs.web }}
-      workflows: ${{ steps.filter.outputs.workflows }}
+      ci_workflow: ${{ steps.filter.outputs.ci_workflow }}
+      workflow_files: ${{ steps.filter.outputs.workflow_files }}
       dispatcher_host: ${{ steps.filter.outputs.dispatcher_host }}
       agent_images: ${{ steps.filter.outputs.agent_images }}
       docs: ${{ steps.filter.outputs.docs }}
@@ -83,7 +84,15 @@ jobs:
               - 'eslint.config.mjs'
               - 'package.json'
               - 'package-lock.json'
-            workflows:
+            ci_workflow:
+              # Editing ci.yml can alter any required job below, so fan out
+              # the full CI matrix on CI workflow changes.
+              - '.github/workflows/ci.yml'
+            workflow_files:
+              # Non-CI workflow edits only need the lightweight YAML guard
+              # below; running the full product test matrix for release or
+              # scheduled workflow edits adds cost without validating those
+              # workflows meaningfully.
               - '.github/workflows/**'
             dispatcher_host:
               - 'deployment/spring-voyage-host.sh'
@@ -151,13 +160,37 @@ jobs:
               - 'platform/runtime-catalog.yaml'
               - 'platform/runtime-catalog.schema.json'
 
+  workflow-yaml:
+    name: Workflow YAML syntax
+    runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.workflow_files == 'true'
+    timeout-minutes: 2
 
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Parse workflow YAML files
+        shell: bash
+        run: |
+          ruby -e '
+            require "yaml"
+
+            paths = Dir[".github/workflows/*.yml"] + Dir[".github/workflows/*.yaml"]
+            paths.sort.each do |path|
+              YAML.load_file(path)
+              puts "ok #{path}"
+            rescue Psych::SyntaxError => e
+              warn "::error file=#{path},line=#{e.line},col=#{e.column}::#{e.message}"
+              exit 1
+            end
+          '
 
   build:
     name: Build
     runs-on: ubuntu-latest
     needs: changes
-    if: needs.changes.outputs.dotnet == 'true' || needs.changes.outputs.workflows == 'true'
+    if: needs.changes.outputs.dotnet == 'true' || needs.changes.outputs.ci_workflow == 'true'
     timeout-minutes: 20
 
     steps:
@@ -186,7 +219,7 @@ jobs:
     name: Test
     runs-on: ubuntu-latest
     needs: [changes, build]
-    if: needs.changes.outputs.dotnet == 'true' || needs.changes.outputs.workflows == 'true'
+    if: needs.changes.outputs.dotnet == 'true' || needs.changes.outputs.ci_workflow == 'true'
     timeout-minutes: 30
 
     steps:
@@ -262,7 +295,7 @@ jobs:
     # output is a function of the PR's own sources.
     if: >
       github.event_name != 'merge_group' &&
-      (needs.changes.outputs.packages == 'true' || needs.changes.outputs.workflows == 'true')
+      (needs.changes.outputs.packages == 'true' || needs.changes.outputs.ci_workflow == 'true')
     timeout-minutes: 10
 
     steps:
@@ -361,7 +394,7 @@ jobs:
     # pull_request run stays valid through the queue.
     if: >
       github.event_name != 'merge_group' &&
-      (needs.changes.outputs.dotnet == 'true' || needs.changes.outputs.workflows == 'true')
+      (needs.changes.outputs.dotnet == 'true' || needs.changes.outputs.ci_workflow == 'true')
     timeout-minutes: 15
 
     steps:
@@ -401,7 +434,7 @@ jobs:
     # or it didn't touch agent definitions.
     if: >
       github.event_name != 'merge_group' &&
-      (needs.changes.outputs.agents == 'true' || needs.changes.outputs.workflows == 'true')
+      (needs.changes.outputs.agents == 'true' || needs.changes.outputs.ci_workflow == 'true')
     timeout-minutes: 10
 
     steps:
@@ -468,7 +501,7 @@ jobs:
     # silently break it.
     if: >
       github.event_name != 'merge_group' &&
-      (needs.changes.outputs.runtime_catalog == 'true' || needs.changes.outputs.workflows == 'true')
+      (needs.changes.outputs.runtime_catalog == 'true' || needs.changes.outputs.ci_workflow == 'true')
     timeout-minutes: 5
 
     steps:
@@ -482,7 +515,8 @@ jobs:
           # `node -e` does not consult global npm modules by default, so make
           # the global install location resolvable via NODE_PATH. The `ajv`
           # CLI itself works without this because npm global bin is on PATH.
-          export NODE_PATH="$(npm root -g)"
+          node_path="$(npm root -g)"
+          export NODE_PATH="$node_path"
           # Convert YAML to JSON in-memory then validate. ajv-cli reads the
           # JSON Schema natively; the YAML→JSON one-liner avoids a separate
           # Python dependency.
@@ -503,7 +537,7 @@ jobs:
     # integration with other merged PRs.
     if: >
       github.event_name != 'merge_group' &&
-      (needs.changes.outputs.connectors_web == 'true' || needs.changes.outputs.workflows == 'true')
+      (needs.changes.outputs.connectors_web == 'true' || needs.changes.outputs.ci_workflow == 'true')
     timeout-minutes: 5
 
     steps:
@@ -520,7 +554,7 @@ jobs:
     # Skipped in the merge queue — pure intra-repo grep with no external deps.
     if: >
       github.event_name != 'merge_group' &&
-      (needs.changes.outputs.docs == 'true' || needs.changes.outputs.workflows == 'true')
+      (needs.changes.outputs.docs == 'true' || needs.changes.outputs.ci_workflow == 'true')
     timeout-minutes: 2
 
     steps:
@@ -555,7 +589,7 @@ jobs:
     # the queue.
     if: >
       github.event_name != 'merge_group' &&
-      (needs.changes.outputs.web == 'true' || needs.changes.outputs.workflows == 'true')
+      (needs.changes.outputs.web == 'true' || needs.changes.outputs.ci_workflow == 'true')
     timeout-minutes: 10
 
     steps:
@@ -585,7 +619,7 @@ jobs:
     # is intentionally broad).
     if: >
       github.event_name != 'merge_group' &&
-      (needs.changes.outputs.web == 'true' || needs.changes.outputs.workflows == 'true')
+      (needs.changes.outputs.web == 'true' || needs.changes.outputs.ci_workflow == 'true')
     timeout-minutes: 10
 
     steps:
@@ -612,7 +646,7 @@ jobs:
     # type-checking.
     if: >
       github.event_name != 'merge_group' &&
-      (needs.changes.outputs.web == 'true' || needs.changes.outputs.workflows == 'true')
+      (needs.changes.outputs.web == 'true' || needs.changes.outputs.ci_workflow == 'true')
     timeout-minutes: 10
 
     steps:
@@ -643,7 +677,7 @@ jobs:
     # see.
     if: >
       github.event_name != 'merge_group' &&
-      (needs.changes.outputs.web == 'true' || needs.changes.outputs.workflows == 'true')
+      (needs.changes.outputs.web == 'true' || needs.changes.outputs.ci_workflow == 'true')
     timeout-minutes: 15
 
     steps:
@@ -700,7 +734,7 @@ jobs:
     # didn't exist.
     if: >
       github.event_name != 'merge_group' &&
-      (needs.changes.outputs.web == 'true' || needs.changes.outputs.workflows == 'true')
+      (needs.changes.outputs.web == 'true' || needs.changes.outputs.ci_workflow == 'true')
     timeout-minutes: 10
 
     steps:
@@ -743,7 +777,7 @@ jobs:
     # pull_request run stays valid through the queue.
     if: >
       github.event_name != 'merge_group' &&
-      (needs.changes.outputs.api_docs == 'true' || needs.changes.outputs.workflows == 'true')
+      (needs.changes.outputs.api_docs == 'true' || needs.changes.outputs.ci_workflow == 'true')
     timeout-minutes: 5
 
     steps:
@@ -789,7 +823,7 @@ jobs:
     # own sources, so it stays valid through the queue.
     if: >
       github.event_name != 'merge_group' &&
-      (needs.changes.outputs.web == 'true' || needs.changes.outputs.workflows == 'true')
+      (needs.changes.outputs.web == 'true' || needs.changes.outputs.ci_workflow == 'true')
     timeout-minutes: 15
 
     steps:
@@ -865,7 +899,7 @@ jobs:
     # while accessibility stays an `error` gate.
     if: >
       github.event_name != 'merge_group' &&
-      (needs.changes.outputs.web == 'true' || needs.changes.outputs.workflows == 'true')
+      (needs.changes.outputs.web == 'true' || needs.changes.outputs.ci_workflow == 'true')
     timeout-minutes: 15
 
     steps:
@@ -919,7 +953,7 @@ jobs:
     # the queue.
     if: >
       github.event_name != 'merge_group' &&
-      (needs.changes.outputs.python_agents == 'true' || needs.changes.outputs.workflows == 'true')
+      (needs.changes.outputs.python_agents == 'true' || needs.changes.outputs.ci_workflow == 'true')
     timeout-minutes: 5
 
     steps:
@@ -946,7 +980,7 @@ jobs:
     name: Test Python agents
     runs-on: ubuntu-latest
     needs: changes
-    if: needs.changes.outputs.python_agents == 'true' || needs.changes.outputs.workflows == 'true'
+    if: needs.changes.outputs.python_agents == 'true' || needs.changes.outputs.ci_workflow == 'true'
     timeout-minutes: 5
 
     steps:
@@ -975,7 +1009,7 @@ jobs:
     name: OpenAPI contract drift
     runs-on: ubuntu-latest
     needs: changes
-    if: needs.changes.outputs.openapi == 'true' || needs.changes.outputs.workflows == 'true'
+    if: needs.changes.outputs.openapi == 'true' || needs.changes.outputs.ci_workflow == 'true'
     timeout-minutes: 15
 
     steps:
@@ -1042,7 +1076,7 @@ jobs:
     name: EF Core model drift
     runs-on: ubuntu-latest
     needs: changes
-    if: needs.changes.outputs.efcore_model == 'true' || needs.changes.outputs.workflows == 'true'
+    if: needs.changes.outputs.efcore_model == 'true' || needs.changes.outputs.ci_workflow == 'true'
     timeout-minutes: 15
 
     steps:
@@ -1094,7 +1128,7 @@ jobs:
     # surface so unrelated PRs don't pay the build cost.
     if: >
       github.event_name != 'merge_group' &&
-      (needs.changes.outputs.dispatcher_host == 'true' || needs.changes.outputs.workflows == 'true')
+      (needs.changes.outputs.dispatcher_host == 'true' || needs.changes.outputs.ci_workflow == 'true')
     timeout-minutes: 15
 
     steps:
@@ -1129,7 +1163,7 @@ jobs:
     # dispatcher-smoke-full.yml and is workflow_dispatch-only.
     if: >
       github.event_name != 'merge_group' &&
-      (needs.changes.outputs.dispatcher_host == 'true' || needs.changes.outputs.workflows == 'true')
+      (needs.changes.outputs.dispatcher_host == 'true' || needs.changes.outputs.ci_workflow == 'true')
     timeout-minutes: 15
 
     steps:
@@ -1177,7 +1211,7 @@ jobs:
     # workflows changes since the audit is over .cs sources.
     if: >
       github.event_name != 'merge_group' &&
-      (needs.changes.outputs.dotnet == 'true' || needs.changes.outputs.workflows == 'true')
+      (needs.changes.outputs.dotnet == 'true' || needs.changes.outputs.ci_workflow == 'true')
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@v6
@@ -1201,7 +1235,7 @@ jobs:
     # python-agent surface so unrelated PRs don't pay the build cost.
     if: >
       github.event_name != 'merge_group' &&
-      (needs.changes.outputs.agent_images == 'true' || needs.changes.outputs.workflows == 'true')
+      (needs.changes.outputs.agent_images == 'true' || needs.changes.outputs.ci_workflow == 'true')
     timeout-minutes: 25
     steps:
       - uses: actions/checkout@v6
@@ -1252,6 +1286,7 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - changes
+      - workflow-yaml
       - build
       - test
       - format
@@ -1310,9 +1345,11 @@ jobs:
           AGENT_IMAGES_RESULT: ${{ needs.agent-images-smoke.result }}
           DOCS_FRAMING_RESULT: ${{ needs.docs-evergreen-framing.result }}
           PACKAGE_VALIDATE_RESULT: ${{ needs.package-validate.result }}
+          WORKFLOW_YAML_RESULT: ${{ needs.workflow-yaml.result }}
           CHANGES_RESULT: ${{ needs.changes.result }}
         run: |
           echo "changes=$CHANGES_RESULT"
+          echo "workflow-yaml=$WORKFLOW_YAML_RESULT"
           echo "build=$BUILD_RESULT"
           echo "test=$TEST_RESULT"
           echo "format=$FORMAT_RESULT"
@@ -1374,3 +1411,4 @@ jobs:
           ok "$AGENT_IMAGES_RESULT"     || { echo "::error::agent-images-smoke failed"; exit 1; }
           ok "$DOCS_FRAMING_RESULT"     || { echo "::error::docs-evergreen-framing failed"; exit 1; }
           ok "$PACKAGE_VALIDATE_RESULT" || { echo "::error::package-validate failed"; exit 1; }
+          ok "$WORKFLOW_YAML_RESULT"    || { echo "::error::workflow-yaml failed"; exit 1; }

--- a/.github/workflows/dependency-submission.yml
+++ b/.github/workflows/dependency-submission.yml
@@ -1,32 +1,40 @@
 # Submits NuGet dependency snapshots to the GitHub dependency graph.
-# This workflow replaces the GitHub-managed "Automatic Dependency Submission"
-# dynamic workflow, which fails on this repo due to a binary-download bug
-# in the pinned version of component-detection it uses.
-#
-# Per GitHub docs: once a repo provides its own dependency submission workflow
-# for an ecosystem, GitHub stops auto-generating the submission for that
-# ecosystem.
+# This pins the component-detection submission action that GitHub also uses
+# for automatic .NET dependency submission.
+# Run this only after merges to main. Merge queue refs are temporary and should
+# not submit dependency graph snapshots.
 
 name: Dependency Submission
 
 on:
   push:
     branches: ["main"]
-  merge_group:
+    paths:
+      - "**/*.csproj"
+      - "**/*.slnx"
+      - "Directory.Build.props"
+      - "Directory.Packages.props"
+      - "global.json"
+      - "NuGet.config"
+      - ".github/workflows/dependency-submission.yml"
 
 permissions:
   contents: write
+  id-token: write
 
 jobs:
   submit-nuget:
     name: submit-nuget
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: actions/setup-dotnet@v5
         with:
           dotnet-version: "10.0.x"
 
       - name: Submit NuGet dependency snapshot
-        uses: actions/nuget-dependency-submission-action@v1
+        uses: advanced-security/component-detection-dependency-submission-action@v0.1.1
+        with:
+          detectorsCategories: NuGet

--- a/.github/workflows/release-agent-base.yml
+++ b/.github/workflows/release-agent-base.yml
@@ -39,6 +39,7 @@ jobs:
   resolve:
     name: Resolve release version
     runs-on: ubuntu-latest
+    timeout-minutes: 2
     outputs:
       tag: ${{ steps.r.outputs.tag }}
       version: ${{ steps.r.outputs.version }}
@@ -72,17 +73,18 @@ jobs:
     name: Sidecar unit tests
     runs-on: ubuntu-latest
     needs: resolve
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: npm
-          cache-dependency-path: deployment/agent-sidecar/package.json
+          cache-dependency-path: deployment/agent-sidecar/package-lock.json
       - name: Install + test
         working-directory: deployment/agent-sidecar
         run: |
-          npm install --no-audit --no-fund
+          npm ci --no-audit --no-fund
           npm run lint
           npm test
           npm run build
@@ -154,6 +156,7 @@ jobs:
     name: Publish @cvoya/spring-voyage-agent-sidecar
     runs-on: ubuntu-latest
     needs: [resolve, test]
+    timeout-minutes: 10
     env:
       RELEASE_VERSION: ${{ needs.resolve.outputs.version }}
     steps:
@@ -163,7 +166,7 @@ jobs:
           node-version: 22
           registry-url: https://registry.npmjs.org
           cache: npm
-          cache-dependency-path: deployment/agent-sidecar/package.json
+          cache-dependency-path: deployment/agent-sidecar/package-lock.json
 
       - name: Sync package.json version with tag
         working-directory: deployment/agent-sidecar
@@ -174,7 +177,7 @@ jobs:
       - name: Install + build
         working-directory: deployment/agent-sidecar
         run: |
-          npm install --no-audit --no-fund
+          npm ci --no-audit --no-fund
           npm run build
 
       - name: Publish (with provenance)
@@ -192,6 +195,7 @@ jobs:
     name: Build single-executable binaries
     runs-on: ${{ matrix.os }}
     needs: [resolve, test]
+    timeout-minutes: 20
     env:
       RELEASE_VERSION: ${{ needs.resolve.outputs.version }}
       TARGET: ${{ matrix.target }}
@@ -211,12 +215,12 @@ jobs:
         with:
           node-version: 22
           cache: npm
-          cache-dependency-path: deployment/agent-sidecar/package.json
+          cache-dependency-path: deployment/agent-sidecar/package-lock.json
 
       - name: Install + build
         working-directory: deployment/agent-sidecar
         run: |
-          npm install --no-audit --no-fund
+          npm ci --no-audit --no-fund
           npm run build
 
       - name: Bundle entrypoint into a single file
@@ -270,7 +274,7 @@ jobs:
           PORT=18999
           AGENT_PORT="$PORT" \
           SPRING_AGENT_ARGV='["true"]' \
-            ./dist/${OUT_NAME} &
+            "./dist/${OUT_NAME}" &
           PID=$!
           for _ in 1 2 3 4 5 6 7 8 9 10; do
             if curl -fs "http://127.0.0.1:${PORT}/healthz" >/dev/null; then
@@ -292,6 +296,7 @@ jobs:
     name: Attach binaries to GitHub Release
     runs-on: ubuntu-latest
     needs: [resolve, publish-image, publish-npm, publish-binaries]
+    timeout-minutes: 10
     env:
       RELEASE_TAG: ${{ needs.resolve.outputs.tag }}
     steps:

--- a/.github/workflows/release-oss-agent-images.yml
+++ b/.github/workflows/release-oss-agent-images.yml
@@ -44,6 +44,7 @@ jobs:
   resolve:
     name: Resolve release version
     runs-on: ubuntu-latest
+    timeout-minutes: 2
     outputs:
       tag: ${{ steps.r.outputs.tag }}
       version: ${{ steps.r.outputs.version }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -97,10 +97,12 @@ jobs:
             is_prerelease="true"
           fi
 
-          echo "tag=$release_tag"             >> "$GITHUB_OUTPUT"
-          echo "version=$release_version"     >> "$GITHUB_OUTPUT"
-          echo "major_minor=$major_minor"     >> "$GITHUB_OUTPUT"
-          echo "is_prerelease=$is_prerelease" >> "$GITHUB_OUTPUT"
+          {
+            echo "tag=$release_tag"
+            echo "version=$release_version"
+            echo "major_minor=$major_minor"
+            echo "is_prerelease=$is_prerelease"
+          } >> "$GITHUB_OUTPUT"
 
           echo "Resolved: tag=$release_tag version=$release_version major_minor=$major_minor is_prerelease=$is_prerelease"
 


### PR DESCRIPTION
## Summary

- Replace the stale NuGet dependency submission action with the documented component-detection action and keep dependency snapshots off merge queue refs.
- Split CI workflow edits from general workflow edits so non-CI workflow changes run a lightweight YAML guard instead of fanning out the full CI matrix.
- Tighten workflow reliability with lockfile-based `npm ci` in the agent-base release workflow, missing job timeouts, and actionlint/shellcheck cleanups.

## Impact

Workflow-only PRs, especially release or dependency-submission edits, should spend much less CI time while still getting a syntax guard through the required check aggregator. The merge queue should also stop seeing the fast-failing `submit-nuget` action resolution error.

## Validation

- `actionlint` 1.7.12
- Parsed all `.github/workflows/*.yml` files with Ruby YAML
- `git diff --check`
- `deployment/agent-sidecar`: `npm ci --no-audit --no-fund`
- `deployment/agent-sidecar`: `npm run lint`
- `deployment/agent-sidecar`: `npm test`
- `deployment/agent-sidecar`: `npm run build`

Full `/build`, `/lint`, and `/test` were not run because this PR only changes GitHub workflow files.
