### PR TITLE
[codex] fix portal explorer url state

### DIFF
--- a/src/Cvoya.Spring.Web/DESIGN.md
+++ b/src/Cvoya.Spring.Web/DESIGN.md
@@ -271,7 +271,7 @@ Selection and active tab live in the query string:
 - `?node=<id>` — the selected node. Defaults to the tenant root.
 - `?tab=<TabName>` — the active tab (one of the kind's catalog entries; see § 9). A stale `tab` value snaps to the kind's first visible tab.
 
-The route writes both via `router.replace(?${qs}, { scroll: false })` so deep-links round-trip without a history push.
+The route writes both via `window.history.replaceState` so deep-links round-trip without a history push or an App Router server-component navigation; a small URL snapshot subscription re-renders the Explorer immediately after local query updates.
 
 ### 7.2 Shape
 

--- a/src/Cvoya.Spring.Web/src/app/units/page.tsx
+++ b/src/Cvoya.Spring.Web/src/app/units/page.tsx
@@ -10,10 +10,10 @@
 // route stays until `DEL-units-id` lands because its tabs still host
 // content the EXP-tab-unit-* issues are migrating into the Explorer.
 
-import { Suspense, useCallback } from "react";
+import { Suspense, useCallback, useMemo, useSyncExternalStore } from "react";
 import Link from "next/link";
 import { AlertCircle, Loader2, Plus } from "lucide-react";
-import { usePathname, useRouter, useSearchParams } from "next/navigation";
+import { usePathname, useSearchParams } from "next/navigation";
 
 import { Card, CardContent } from "@/components/ui/card";
 import { UnitExplorer } from "@/components/units/unit-explorer";
@@ -29,10 +29,38 @@ import type { ValidatedTenantTreeNode } from "@/lib/api/validate-tenant-tree";
 // until a user actually browses to `/units`.
 import "@/components/units/tabs/register-all";
 
+const EXPLORER_URL_CHANGE_EVENT = "spring-voyage:explorer-url-change";
+
+function subscribeExplorerUrl(onStoreChange: () => void): () => void {
+  window.addEventListener("popstate", onStoreChange);
+  window.addEventListener(EXPLORER_URL_CHANGE_EVENT, onStoreChange);
+  return () => {
+    window.removeEventListener("popstate", onStoreChange);
+    window.removeEventListener(EXPLORER_URL_CHANGE_EVENT, onStoreChange);
+  };
+}
+
+function getExplorerUrlSnapshot(): string {
+  return window.location.search;
+}
+
+function getServerExplorerUrlSnapshot(): string {
+  return "";
+}
+
 function UnitExplorerRoute() {
-  const router = useRouter();
   const pathname = usePathname();
-  const searchParams = useSearchParams();
+  const routerSearchParams = useSearchParams();
+  const historySearch = useSyncExternalStore(
+    subscribeExplorerUrl,
+    getExplorerUrlSnapshot,
+    getServerExplorerUrlSnapshot,
+  );
+  const routerSearch = routerSearchParams.toString();
+  const searchParams = useMemo(
+    () => new URLSearchParams(historySearch || routerSearch),
+    [historySearch, routerSearch],
+  );
 
   const selectedId = searchParams.get("node") ?? undefined;
   const tab = (searchParams.get("tab") as TabName | null) ?? undefined;
@@ -55,15 +83,15 @@ function UnitExplorerRoute() {
       }
       if (next.tab !== undefined) params.set("tab", next.tab);
       const qs = params.toString();
-      // #1039: Next.js 16's `router.replace("?foo=bar")` with a bare
-      // query-only relative URL doesn't update the canonical URL — the
-      // reconciler's `replaceState` call fires with the stale query, so
-      // the URL (and controlled `tab`/`node` props derived from it) snap
-      // back to the prior value the moment React commits. Passing the
-      // full pathname alongside the query restores the intended navigation.
-      router.replace(qs ? `${pathname}?${qs}` : pathname, { scroll: false });
+      const target = qs ? `${pathname}?${qs}` : pathname;
+      // The Explorer's node/tab state is fully client-owned. Using the
+      // App Router here creates an RSC navigation for every tab click;
+      // native history keeps the URL contract without letting a pending
+      // route transition pin the visible tab.
+      window.history.replaceState(null, "", target);
+      window.dispatchEvent(new Event(EXPLORER_URL_CHANGE_EVENT));
     },
-    [searchParams, pathname, router],
+    [searchParams, pathname],
   );
 
   const handleSelectNode = useCallback(
@@ -130,7 +158,7 @@ function UnitExplorerRoute() {
           tree={tree}
           selectedId={selectedId}
           onSelectNode={handleSelectNode}
-          tab={tab ?? undefined}
+          tab={tab}
           onTabChange={handleTabChange}
         />
       </div>

--- a/src/Cvoya.Spring.Web/src/app/units/units-page.test.tsx
+++ b/src/Cvoya.Spring.Web/src/app/units/units-page.test.tsx
@@ -10,9 +10,11 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import UnitsPage from "./page";
 import type { ValidatedTenantTreeNode } from "@/lib/api/validate-tenant-tree";
 
-// Stable router mocks — router.replace is spied so we can assert URL
-// updates when selection or tab changes.
-const replaceMock = vi.fn();
+// Stable router mocks. Explorer node/tab changes now use native
+// history.replaceState so tab clicks don't route through the App Router;
+// router.replace stays spied to prove those local URL writes remain local.
+const routerReplaceMock = vi.fn();
+const historyReplaceStateMock = vi.fn();
 let currentSearchParams = new URLSearchParams();
 
 vi.mock("next/navigation", async () => {
@@ -20,16 +22,7 @@ vi.mock("next/navigation", async () => {
   return {
     useRouter: () => ({
       push: vi.fn(),
-      replace: (url: string) => {
-        replaceMock(url);
-        // Accept both `?foo=bar` and `/path?foo=bar` — the route now passes
-        // the pathname alongside the query (#1039) because Next.js 16's
-        // `router.replace("?…")` dropped the canonical-URL update.
-        const qIdx = url.indexOf("?");
-        const qs = qIdx >= 0 ? url.slice(qIdx + 1) : "";
-        currentSearchParams = new URLSearchParams(qs);
-        subscribers.forEach((fn) => fn());
-      },
+      replace: routerReplaceMock,
       refresh: vi.fn(),
       back: vi.fn(),
       prefetch: vi.fn(),
@@ -135,12 +128,24 @@ const sampleTree: ValidatedTenantTreeNode = {
 
 describe("UnitsPage — Explorer route (EXP-route)", () => {
   beforeEach(() => {
-    replaceMock.mockClear();
+    routerReplaceMock.mockClear();
+    historyReplaceStateMock.mockClear();
     currentSearchParams = new URLSearchParams();
     useTenantTreeMock.mockReset();
+    vi.spyOn(window.history, "replaceState").mockImplementation(
+      (state, title, url) => {
+        historyReplaceStateMock(state, title, url);
+        const target = url?.toString() ?? window.location.href;
+        const qIdx = target.indexOf("?");
+        const qs = qIdx >= 0 ? target.slice(qIdx + 1) : "";
+        currentSearchParams = new URLSearchParams(qs);
+        subscribers.forEach((fn) => fn());
+      },
+    );
   });
   afterEach(() => {
     subscribers.clear();
+    vi.restoreAllMocks();
   });
 
   it("renders the loading state while the tree is fetching", () => {
@@ -211,8 +216,11 @@ describe("UnitsPage — Explorer route (EXP-route)", () => {
     await screen.findByTestId("unit-explorer");
 
     fireEvent.click(screen.getByTestId("tree-row-engineering"));
-    await waitFor(() => expect(replaceMock).toHaveBeenCalled());
-    expect(replaceMock.mock.calls.at(-1)?.[0]).toMatch(/node=engineering/);
+    await waitFor(() => expect(historyReplaceStateMock).toHaveBeenCalled());
+    const urlAfterSelect =
+      historyReplaceStateMock.mock.calls.at(-1)?.[2]?.toString() ?? "";
+    expect(urlAfterSelect).toMatch(/node=engineering/);
+    expect(routerReplaceMock).not.toHaveBeenCalled();
   });
 
   it("#1704: clears a stale ?tab when switching to a different node kind", async () => {
@@ -229,16 +237,17 @@ describe("UnitsPage — Explorer route (EXP-route)", () => {
     render(wrap(<UnitsPage />));
     await screen.findByTestId("unit-explorer");
 
-    // Click the Engineering unit. The stale ?tab=Agents is valid for a Unit,
-    // so it carries over (correct). Then click Marketing — we just need the
-    // first write to confirm the node switches without re-carrying the tab.
-    replaceMock.mockClear();
+    // Click a Unit row. The stale root-level `?tab=Agents` must not ride
+    // along; switching nodes without an explicit tab clears the old value.
+    historyReplaceStateMock.mockClear();
     fireEvent.click(screen.getByTestId("tree-row-marketing"));
-    await waitFor(() => expect(replaceMock).toHaveBeenCalled());
-    const urlAfterSwitch = replaceMock.mock.calls.at(-1)?.[0] ?? "";
+    await waitFor(() => expect(historyReplaceStateMock).toHaveBeenCalled());
+    const urlAfterSwitch =
+      historyReplaceStateMock.mock.calls.at(-1)?.[2]?.toString() ?? "";
     // Node must update and the stale cross-kind tab must be cleared.
     expect(urlAfterSwitch).toMatch(/node=marketing/);
     expect(urlAfterSwitch).not.toMatch(/tab=/);
+    expect(routerReplaceMock).not.toHaveBeenCalled();
   });
 
   it("renders a 'New unit' link in the page header pointing to /units/create (#1069)", async () => {
@@ -266,8 +275,10 @@ describe("UnitsPage — Explorer route (EXP-route)", () => {
     await screen.findByTestId("unit-explorer");
 
     fireEvent.click(screen.getByTestId("detail-tab-activity"));
-    await waitFor(() => expect(replaceMock).toHaveBeenCalled());
-    const last = replaceMock.mock.calls.at(-1)?.[0] ?? "";
+    await waitFor(() => expect(historyReplaceStateMock).toHaveBeenCalled());
+    const last =
+      historyReplaceStateMock.mock.calls.at(-1)?.[2]?.toString() ?? "";
     expect(last).toMatch(/tab=Activity/);
+    expect(routerReplaceMock).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary

Fixes the Units Explorer tab/selection URL update path so local Explorer state changes no longer go through an App Router navigation.

## Root Cause

The Explorer stores the selected node and active tab in the query string. The route previously used `router.replace(...)` for every tree or tab click. In Next App Router that still issues a server-component navigation for `/units?...`, which can leave the tab UI waiting on or racing with a pending route transition. That matches the reported symptom: the view appears stuck across route changes and only recovers later when the pending navigation/cache state settles.

## Changes

- Replace Explorer node/tab URL writes with `window.history.replaceState`.
- Add a tiny URL snapshot subscription around `popstate` and the local Explorer URL-change event so the controlled Explorer props re-render immediately after local query updates.
- Update the route-level tests to assert local URL writes do not call `router.replace`.
- Update `src/Cvoya.Spring.Web/DESIGN.md` to keep the Explorer URL contract current.

## Validation

- `npm --prefix src/Cvoya.Spring.Web test -- src/app/units/units-page.test.tsx src/components/units/unit-explorer.test.tsx src/components/units/unit-detail-pane.test.tsx`
- Browser probe against the patched dev server: switching across Unit tabs updated selected tab + URL immediately and produced `0` `/units?...&_rsc=` requests.
- `/build`: `dotnet build SpringVoyage.slnx --configuration Release`
- `/lint`: `dotnet format SpringVoyage.slnx --verify-no-changes && npm run lint && npm --workspace=spring-voyage-dashboard run knip && npm --workspace=spring-voyage-dashboard run typecheck`
- `/test`: `dotnet test --solution SpringVoyage.slnx --no-restore --no-build --configuration Release`
