### PR TITLE
[codex] Fix unit execution model selection

### DIFF
--- a/src/Cvoya.Spring.Web/src/components/units/tab-impls/execution-tab.test.tsx
+++ b/src/Cvoya.Spring.Web/src/components/units/tab-impls/execution-tab.test.tsx
@@ -150,6 +150,49 @@ describe("ExecutionTab", () => {
     ).not.toBeInTheDocument();
   });
 
+  it("selects and saves a model for a fixed-provider runtime", async () => {
+    getUnitExecution.mockResolvedValue({ runtime: "claude-code" });
+    getModelProviderModels.mockImplementation(async (id: string) => {
+      if (id === "anthropic") {
+        return [
+          { id: "claude-sonnet-4-6", displayName: "claude-sonnet-4-6", contextWindow: null },
+          { id: "claude-opus-4-7", displayName: "claude-opus-4-7", contextWindow: null },
+        ];
+      }
+      return [];
+    });
+    setUnitExecution.mockImplementation(async (_id, body) => body);
+
+    render(
+      <Wrapper>
+        <ExecutionTab unitId="eng-team" />
+      </Wrapper>,
+    );
+
+    const modelSelect = (await screen.findByTestId(
+      "execution-model-select",
+    )) as HTMLSelectElement;
+    fireEvent.change(modelSelect, {
+      target: { value: "claude-sonnet-4-6" },
+    });
+
+    expect(modelSelect.value).toBe("claude-sonnet-4-6");
+
+    fireEvent.click(screen.getByRole("button", { name: /^Save$/i }));
+
+    await waitFor(() => {
+      expect(setUnitExecution).toHaveBeenCalledTimes(1);
+    });
+    const [, body] = setUnitExecution.mock.calls[0];
+    expect(body).toMatchObject({
+      runtime: "claude-code",
+      model: {
+        provider: "anthropic",
+        id: "claude-sonnet-4-6",
+      },
+    });
+  });
+
   it("renders a Model dropdown populated from the runtime's catalog when agent=codex (#641)", async () => {
     getUnitExecution.mockResolvedValue({ runtime: "codex" });
     getModelProviderModels.mockImplementation(async (id: string) => {
@@ -202,6 +245,53 @@ describe("ExecutionTab", () => {
     // Model renders as a free-text input because no Provider is
     // selected yet, so there's no catalog to drive a dropdown.
     expect(screen.getByTestId("execution-model-input")).toBeInTheDocument();
+  });
+
+  it("keeps Model Provider selected as a catalog filter before the model is chosen", async () => {
+    getUnitExecution.mockResolvedValue({ runtime: "spring-voyage" });
+    listModelProviders.mockResolvedValue([{ id: "anthropic" }]);
+    getModelProviderModels.mockImplementation(async (id: string) => {
+      if (id === "anthropic") {
+        return [
+          { id: "claude-sonnet-4-6", displayName: "claude-sonnet-4-6", contextWindow: null },
+        ];
+      }
+      return [];
+    });
+    setUnitExecution.mockImplementation(async (_id, body) => body);
+
+    render(
+      <Wrapper>
+        <ExecutionTab unitId="eng-team" />
+      </Wrapper>,
+    );
+
+    const providerSelect = (await screen.findByTestId(
+      "execution-provider-select",
+    )) as HTMLSelectElement;
+    fireEvent.change(providerSelect, { target: { value: "anthropic" } });
+
+    expect(providerSelect.value).toBe("anthropic");
+    await waitFor(() => {
+      expect(getModelProviderModels).toHaveBeenCalledWith("anthropic");
+    });
+
+    const modelSelect = (await screen.findByTestId(
+      "execution-model-select",
+    )) as HTMLSelectElement;
+    fireEvent.change(modelSelect, {
+      target: { value: "claude-sonnet-4-6" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /^Save$/i }));
+
+    await waitFor(() => {
+      expect(setUnitExecution).toHaveBeenCalledTimes(1);
+    });
+    const [, body] = setUnitExecution.mock.calls[0];
+    expect(body?.model).toEqual({
+      provider: "anthropic",
+      id: "claude-sonnet-4-6",
+    });
   });
 
   it("keeps the Model slot visible when agent=custom (always rendered post-#1702)", async () => {

--- a/src/Cvoya.Spring.Web/src/components/units/tab-impls/execution-tab.tsx
+++ b/src/Cvoya.Spring.Web/src/components/units/tab-impls/execution-tab.tsx
@@ -66,17 +66,45 @@ interface ExecutionTabProps {
 
 const FIELD_UNSET = "__unset__";
 
+type ModelDraft = {
+  provider: string | null;
+  id: string | null;
+};
+
+type UnitExecutionDraft = Omit<UnitExecutionResponse, "model"> & {
+  model: ModelDraft | null;
+};
+
 function isEmpty(block: UnitExecutionResponse): boolean {
   return !block.image && !block.runtime && !block.model;
 }
 
 function persistedToForm(
   persisted: UnitExecutionResponse | null,
-): UnitExecutionResponse {
+): UnitExecutionDraft {
   return {
     image: persisted?.image ?? null,
     runtime: persisted?.runtime ?? null,
-    model: persisted?.model ?? null,
+    model: persisted?.model
+      ? {
+          provider: persisted.model.provider,
+          id: persisted.model.id,
+        }
+      : null,
+  };
+}
+
+function toPayload(form: UnitExecutionDraft): UnitExecutionResponse {
+  return {
+    image: form.image ?? null,
+    runtime: form.runtime ?? null,
+    model:
+      form.model?.provider && form.model.id
+        ? {
+            provider: form.model.provider,
+            id: form.model.id,
+          }
+        : null,
   };
 }
 
@@ -92,10 +120,10 @@ export function ExecutionTab({ unitId }: ExecutionTabProps) {
 
   const persisted = executionQuery.data ?? null;
 
-  // Local draft mirrors the wire shape directly. No flat-form
-  // intermediate; no `formToWire` projector. Re-seeded whenever the
-  // server identity changes.
-  const [form, setForm] = useState<UnitExecutionResponse>(() =>
+  // Local draft keeps a provider-only selection so the provider picker
+  // can act as a model-catalogue filter. Saves still go through
+  // `toPayload`, which only emits complete `{ provider, id }` models.
+  const [form, setForm] = useState<UnitExecutionDraft>(() =>
     persistedToForm(null),
   );
   const [seededFor, setSeededFor] = useState<string | null>(null);
@@ -110,12 +138,13 @@ export function ExecutionTab({ unitId }: ExecutionTabProps) {
   }
 
   const dirty = useMemo(() => {
-    const current = persistedToForm(persisted);
+    const current = toPayload(persistedToForm(persisted));
+    const next = toPayload(form);
     return (
-      form.image !== current.image ||
-      form.runtime !== current.runtime ||
-      (form.model?.provider ?? null) !== (current.model?.provider ?? null) ||
-      (form.model?.id ?? null) !== (current.model?.id ?? null)
+      next.image !== current.image ||
+      next.runtime !== current.runtime ||
+      (next.model?.provider ?? null) !== (current.model?.provider ?? null) ||
+      (next.model?.id ?? null) !== (current.model?.id ?? null)
     );
   }, [form, persisted]);
 
@@ -196,16 +225,22 @@ export function ExecutionTab({ unitId }: ExecutionTabProps) {
     },
   });
 
-  // Mutate the model object as a unit. Setting either provider or id
-  // alone produces a partial model — the wire shape requires both
-  // keys, so we collapse partial entries to `null`.
+  // Mutate the model object as a draft unit. The UI may hold provider
+  // without id while it loads a catalogue; `toPayload` strips partial
+  // model drafts before save.
   const setModelField = (key: "provider" | "id", value: string | null) => {
     setForm((prev) => {
+      const previousProvider = prev.model?.provider ?? null;
       const nextProvider =
-        key === "provider" ? value : (prev.model?.provider ?? null);
-      const nextId = key === "id" ? value : (prev.model?.id ?? null);
+        key === "provider" ? value : (previousProvider ?? effectiveProvider);
+      const nextId =
+        key === "id"
+          ? value
+          : value && value === previousProvider
+            ? (prev.model?.id ?? null)
+            : null;
       const model =
-        nextProvider && nextId
+        nextProvider || nextId
           ? { provider: nextProvider, id: nextId }
           : null;
       return { ...prev, model };
@@ -228,7 +263,7 @@ export function ExecutionTab({ unitId }: ExecutionTabProps) {
           ? (prev.model?.id ?? null)
           : null;
       const model =
-        nextProvider && keepModelId
+        nextProvider || keepModelId
           ? { provider: nextProvider, id: keepModelId }
           : null;
       return { ...prev, runtime: next, model };
@@ -242,13 +277,20 @@ export function ExecutionTab({ unitId }: ExecutionTabProps) {
     if (field === "image") next = { ...form, image: null };
     if (field === "runtime") next = { ...form, runtime: null, model: null };
     if (field === "providerOnly") next = { ...form, model: null };
-    if (field === "model") next = { ...form, model: null };
+    if (field === "model") {
+      next = {
+        ...form,
+        model: form.model?.provider
+          ? { provider: form.model.provider, id: null }
+          : null,
+      };
+    }
     setForm(next);
-    setMutation.mutate(next);
+    setMutation.mutate(toPayload(next));
   };
 
   const handleSave = () => {
-    setMutation.mutate(form);
+    setMutation.mutate(toPayload(form));
   };
 
   if (executionQuery.isPending) {


### PR DESCRIPTION
## Summary

Fixes the unit Execution tab model selector so fixed-provider runtimes, such as Claude Code, keep the chosen model instead of snapping back to `(leave to default)`.

## Root Cause

The unit execution form mirrored the API payload too strictly. Selecting a model for a fixed-provider runtime changed only the model id while the provider picker was hidden, so the draft briefly contained a partial model and collapsed it back to `null`.

## Changes

- Add a UI-only unit execution draft model that can retain provider-only state for catalogue filtering.
- Convert drafts back to the wire payload before save so the API still receives only complete `{ provider, id }` models.
- Add regression tests for Claude Code fixed-provider model selection and the Spring Voyage provider-as-filter flow.

## Validation

- `dotnet build SpringVoyage.slnx --configuration Release`
- `dotnet format SpringVoyage.slnx --verify-no-changes`
- `npm run lint`
- `npm --workspace=spring-voyage-dashboard run knip`
- `npm --workspace=spring-voyage-dashboard run typecheck`
- `dotnet test --solution SpringVoyage.slnx --no-restore --no-build --configuration Release`
- `npm --workspace=spring-voyage-dashboard test -- src/components/units/tab-impls/execution-tab.test.tsx`
