### PR TITLE
feat(release): Homebrew formula and auto-bump for spring CLI (#2178)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,8 @@ name: Spring Voyage — Release
 #                        └─→ ... ┬─→ publish-sha256sums   (needs every release-attached job)
 #                                ▼
 #                        finalize-release (promote draft → published)
+#                                │
+#                        bump-homebrew-formula (stable releases only)
 #
 # Why ci-gate instead of re-running build/test (#2027): tags must point at a
 # commit that is already on main, and main is gated by ci.yml's "Required
@@ -1644,3 +1646,81 @@ jobs:
             --repo "${REPO}" \
             ${prerelease_flag}
           echo "GitHub Release published: https://github.com/${REPO}/releases/tag/${RELEASE_TAG}"
+
+  # ── 14. Bump Homebrew formula ──────────────────────────────────────────────
+  #
+  # After the release is public, push the rendered formula to
+  # cvoya-com/homebrew-tap so that `brew install cvoya-com/tap/spring-voyage`
+  # serves the new version.
+  #
+  # Only stable (non-prerelease) releases update the tap formula; RC / alpha
+  # tarballs are not surfaced through Homebrew.
+  #
+  # Requires the TAP_GITHUB_TOKEN secret: a classic PAT (or GitHub App
+  # installation token) with `contents: write` on cvoya-com/homebrew-tap.
+  # The job skips gracefully when the secret is absent so the release pipeline
+  # keeps working while the tap is being bootstrapped.
+  bump-homebrew-formula:
+    name: Bump Homebrew formula (spring-voyage)
+    runs-on: ubuntu-latest
+    needs:
+      - resolve
+      - finalize-release
+    if: needs.resolve.outputs.is_prerelease == 'false'
+    timeout-minutes: 10
+    env:
+      RELEASE_VERSION: ${{ needs.resolve.outputs.version }}
+      RELEASE_TAG: ${{ needs.resolve.outputs.tag }}
+      TAP_GITHUB_TOKEN: ${{ secrets.TAP_GITHUB_TOKEN }}
+
+    steps:
+      - name: Checkout (formula template only)
+        uses: actions/checkout@v6
+        with:
+          sparse-checkout: |
+            eng/homebrew
+          sparse-checkout-cone-mode: false
+
+      - name: Download SHA256SUMS from release
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          gh release download "${RELEASE_TAG}" \
+            --repo "${REPO}" \
+            --pattern "SHA256SUMS" \
+            --output SHA256SUMS
+          echo "--- SHA256SUMS ---"
+          cat SHA256SUMS
+
+      - name: Render formula from template
+        shell: bash
+        run: |
+          set -euo pipefail
+          bash eng/homebrew/bump-formula.sh \
+            "${RELEASE_VERSION}" \
+            SHA256SUMS \
+            spring-voyage.rb
+
+      - name: Push formula to tap
+        if: ${{ env.TAP_GITHUB_TOKEN != '' }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          git clone \
+            "https://x-access-token:${TAP_GITHUB_TOKEN}@github.com/cvoya-com/homebrew-tap.git" \
+            tap
+          mkdir -p tap/Formula
+          cp spring-voyage.rb tap/Formula/spring-voyage.rb
+          cd tap
+          git config user.email "savasp-agent[bot]@users.noreply.github.com"
+          git config user.name "savasp-agent[bot]"
+          git add Formula/spring-voyage.rb
+          if git diff --cached --quiet; then
+            echo "Formula unchanged — nothing to push."
+          else
+            git commit -m "chore: bump spring-voyage to ${RELEASE_VERSION}"
+            git push
+          fi

--- a/eng/homebrew/bump-formula.sh
+++ b/eng/homebrew/bump-formula.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# Render the Homebrew formula from the template, substituting version and SHAs
+# extracted from a SHA256SUMS file produced by the release workflow.
+#
+# Usage: bump-formula.sh <version> <sha256sums-file> <output.rb>
+#
+# Arguments:
+#   version        Semantic version string, e.g. 1.0.0
+#   sha256sums-file  Path to the SHA256SUMS file attached to the GitHub release
+#   output.rb      Destination path for the rendered formula
+set -euo pipefail
+
+VERSION="${1:?version required}"
+SHA256SUMS="${2:?sha256sums-file required}"
+OUTPUT="${3:?output.rb required}"
+
+TEMPLATE="$(cd "$(dirname "$0")" && pwd)/spring-voyage.rb.tmpl"
+
+if [[ ! -f "${TEMPLATE}" ]]; then
+  echo "::error::formula template not found: ${TEMPLATE}" >&2
+  exit 1
+fi
+
+if [[ ! -f "${SHA256SUMS}" ]]; then
+  echo "::error::SHA256SUMS file not found: ${SHA256SUMS}" >&2
+  exit 1
+fi
+
+SHA_ARM64=$(grep "spring-voyage-${VERSION}-osx-arm64\\.tar\\.gz" "${SHA256SUMS}" | awk '{print $1}')
+SHA_X64=$(  grep "spring-voyage-${VERSION}-osx-x64\\.tar\\.gz"   "${SHA256SUMS}" | awk '{print $1}')
+
+if [[ -z "${SHA_ARM64}" ]]; then
+  echo "::error::SHA256 for osx-arm64 not found in ${SHA256SUMS}" >&2
+  exit 1
+fi
+
+if [[ -z "${SHA_X64}" ]]; then
+  echo "::error::SHA256 for osx-x64 not found in ${SHA256SUMS}" >&2
+  exit 1
+fi
+
+sed \
+  -e "s/{{VERSION}}/${VERSION}/g" \
+  -e "s/{{SHA256_OSX_ARM64}}/${SHA_ARM64}/g" \
+  -e "s/{{SHA256_OSX_X64}}/${SHA_X64}/g" \
+  "${TEMPLATE}" > "${OUTPUT}"
+
+echo "Generated ${OUTPUT}:"
+cat "${OUTPUT}"

--- a/eng/homebrew/spring-voyage.rb.tmpl
+++ b/eng/homebrew/spring-voyage.rb.tmpl
@@ -1,0 +1,26 @@
+class SpringVoyage < Formula
+  desc "CLI for operating the Spring Voyage agent platform"
+  homepage "https://github.com/cvoya-com/spring-voyage"
+  license "BUSL-1.1"
+  version "{{VERSION}}"
+
+  on_macos do
+    on_arm do
+      url "https://github.com/cvoya-com/spring-voyage/releases/download/spring-voyage-v#{version}/spring-voyage-#{version}-osx-arm64.tar.gz"
+      sha256 "{{SHA256_OSX_ARM64}}"
+    end
+    on_intel do
+      url "https://github.com/cvoya-com/spring-voyage/releases/download/spring-voyage-v#{version}/spring-voyage-#{version}-osx-x64.tar.gz"
+      sha256 "{{SHA256_OSX_X64}}"
+    end
+  end
+
+  def install
+    bin.install "cli/spring"
+  end
+
+  test do
+    output = shell_output("#{bin}/spring --version 2>&1")
+    assert_match version.to_s, output
+  end
+end


### PR DESCRIPTION
## Summary

Closes #2178.

- **`eng/homebrew/spring-voyage.rb.tmpl`** — Homebrew formula template for `spring` CLI, supporting both Apple Silicon (`osx-arm64`) and Intel (`osx-x64`) via the `on_macos` / `on_arm` / `on_intel` DSL. Installs `cli/spring` from the per-RID release archive; includes a `test` block that asserts `spring --version` matches the formula version.
- **`eng/homebrew/bump-formula.sh`** — Script that extracts the two macOS SHA256 entries from `SHA256SUMS` and renders the formula template. Used by CI and runnable locally for testing.
- **`bump-homebrew-formula` job in `release.yml`** — Fires after `finalize-release` for stable (non-prerelease) tags only. Downloads `SHA256SUMS` from the published release, renders the formula, and pushes `Formula/spring-voyage.rb` to `cvoya-com/homebrew-tap`. Skips gracefully when `TAP_GITHUB_TOKEN` is absent so the release pipeline keeps working while the tap is bootstrapped.

## Test plan

- [ ] Verify `eng/homebrew/bump-formula.sh 1.0.0 SHA256SUMS spring-voyage.rb` produces a valid formula with correct SHAs and version
- [ ] Confirm `brew install cvoya-com/tap/spring-voyage` resolves and installs `spring` after the tap is seeded
- [ ] Cut a stable release tag and verify the `bump-homebrew-formula` job runs green (requires `TAP_GITHUB_TOKEN` secret set on the repo)
- [ ] Cut a pre-release tag and confirm the job is skipped (`is_prerelease == 'true'`)

## Setup required

Add a secret `TAP_GITHUB_TOKEN` to `cvoya-com/spring-voyage` with `contents: write` on `cvoya-com/homebrew-tap`. Until the secret is present the job no-ops on every stable release.

https://claude.ai/code/session_0152xRZuxA89HkmMgCAYdAZN

---
_Generated by [Claude Code](https://claude.ai/code/session_0152xRZuxA89HkmMgCAYdAZN)_