### PR TITLE
fix(web): expand/collapse branch nodes when clicking their label in the explorer

### DIFF
--- a/src/Cvoya.Spring.Web/src/components/units/unit-tree.tsx
+++ b/src/Cvoya.Spring.Web/src/components/units/unit-tree.tsx
@@ -53,9 +53,9 @@ interface UnitTreeProps {
  *
  * The container carries `role="tree"`. Each row is a `treeitem` with
  * `aria-selected`, `aria-level`, and (for branches) `aria-expanded`. Click
- * on the row body selects the node; click on the twisty toggles
- * expansion without changing selection — operators can survey a subtree
- * without losing context.
+ * on the row body selects the node and, for branch nodes, toggles
+ * expansion; the twisty button also toggles expansion without changing
+ * selection — operators can survey a subtree without losing context.
  *
  * Keyboard navigation follows the APG treeview pattern: arrow keys walk
  * visible rows, Home/End jump to extremes, →/← expand/collapse (or
@@ -362,7 +362,7 @@ function TreeRow({
         data-testid={`tree-row-${node.id}`}
         data-kind={node.kind}
         data-status={node.status}
-        onClick={() => onSelect(node.id)}
+        onClick={() => { onSelect(node.id); if (hasChildren) onToggle(node.id); }}
         // Indentation is driven by aria-level: 14px per level, plus 8px
         // outside padding so the twisty has a comfortable hit target on
         // the very first level.


### PR DESCRIPTION
## Summary

- Clicking an entry label in the explorer view now toggles expand/collapse for branch nodes, in addition to selecting them.
- The twisty button continues to work as before (toggle only, no selection change).
- Change is a single line in `unit-tree.tsx`: adds `if (hasChildren) onToggle(node.id)` to the row's `onClick` handler.

Closes #2915.

## Test plan

- [ ] Click a branch node label in the explorer — it should select **and** expand/collapse.
- [ ] Click the twisty (▸/▾) — it should still toggle without changing selection.
- [ ] Click a leaf node label — it should select only (no expand/collapse, since `hasChildren` is false).
- [ ] Keyboard navigation (→/← arrows) still works correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)